### PR TITLE
fix(luacheck): delete unused loop variable

### DIFF
--- a/lua/reviewit/ui.lua
+++ b/lua/reviewit/ui.lua
@@ -225,7 +225,7 @@ function M.refresh_extmarks()
 	end
 
 	-- Pending comment indicators (GitHub pending review)
-	for key, comment_data in pairs(state.pending_comments) do
+	for key, _ in pairs(state.pending_comments) do
 		local parsed = comments_mod.parse_draft_key(key)
 		if parsed and parsed.type == "comment" and parsed.path == rel_path then
 			pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, parsed.start_line - 1, 0, {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/flexphere/reviewit.nvim/pull/1.

Fixed this warning.

```sh
Checking lua/reviewit/ui.lua                      1 warning

    lua/reviewit/ui.lua:228:11: unused loop variable comment_data
```

ref: https://github.com/flexphere/reviewit.nvim/actions/runs/22544720120/job/65306910897?pr=1
