### PR TITLE
feat: add ]s/[s section jump keymaps in Overview

### DIFF
--- a/lua/reviewit/ui.lua
+++ b/lua/reviewit/ui.lua
@@ -291,7 +291,7 @@ function M.build_overview_lines(pr_info, issue_comments, format_date_fn)
 
 	-- Footer
 	table.insert(lines, "")
-	table.insert(lines, " 'd/'s/'c: sections  C: new comment  R: refresh  q: close")
+	table.insert(lines, " ]s/[s: sections  C: new comment  R: refresh  q: close")
 	table.insert(hl_ranges, { line = #lines - 1, hl = "Comment" })
 
 	return { lines = lines, hl_ranges = hl_ranges, check_urls = check_urls, sections = sections }
@@ -640,6 +640,33 @@ function M.show_overview_float(pr_info, issue_comments, opts)
 			opts.on_refresh()
 		end
 	end, { buffer = buf, desc = "Refresh PR overview" })
+
+	-- Section jump keymaps
+	local section_lines = {}
+	for _, line in pairs(result.sections) do
+		table.insert(section_lines, line)
+	end
+	table.sort(section_lines)
+
+	vim.keymap.set("n", "]s", function()
+		local cur_line = vim.api.nvim_win_get_cursor(win)[1]
+		for _, line in ipairs(section_lines) do
+			if line > cur_line then
+				vim.api.nvim_win_set_cursor(win, { line, 0 })
+				return
+			end
+		end
+	end, { buffer = buf, desc = "Next section" })
+
+	vim.keymap.set("n", "[s", function()
+		local cur_line = vim.api.nvim_win_get_cursor(win)[1]
+		for i = #section_lines, 1, -1 do
+			if section_lines[i] < cur_line then
+				vim.api.nvim_win_set_cursor(win, { section_lines[i], 0 })
+				return
+			end
+		end
+	end, { buffer = buf, desc = "Previous section" })
 
 	setup_github_refs(buf, get_repo_base_url(pr_info.url), result.check_urls)
 end


### PR DESCRIPTION
## Summary
- Overview表示時に `]s` / `[s` でセクション間（DESCRIPTION → CI STATUS → COMMENTS）をジャンプできるようにした
- フッターのキーバインドヒントを `'d/'s/'c` から `]s/[s` に更新

## Changes
- `lua/reviewit/ui.lua`: `show_overview_float()` に `]s`/`[s` バッファローカルキーマップを追加。既存の `sections` テーブルを活用してソート済みセクション行リストを構築し、次/前のセクションへカーソル移動する

## Test plan
- [x] `run_tests.sh` 全テストパス
- [ ] Neovim で `ReviewOverview` → `]s` で次のセクションへジャンプ
- [ ] `[s` で前のセクションへジャンプ
- [ ] 最後のセクションで `]s` を押しても何も起きないことを確認
- [ ] 最初のセクションで `[s` を押しても何も起きないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)