### PR TITLE
Sort CI checks by status priority in overview

### DIFF
--- a/lua/reviewit/ui.lua
+++ b/lua/reviewit/ui.lua
@@ -127,8 +127,10 @@ function M.normalize_check(check)
 
 	-- StatusContext: has state field (uppercase: "SUCCESS", "FAILURE", "PENDING", "ERROR", "EXPECTED")
 	local state = (check.state or ""):upper()
-	if state == "SUCCESS" or state == "EXPECTED" then
+	if state == "SUCCESS" then
 		return "COMPLETED", "SUCCESS"
+	elseif state == "EXPECTED" then
+		return "PENDING", ""
 	elseif state == "FAILURE" then
 		return "COMPLETED", "FAILURE"
 	elseif state == "ERROR" then
@@ -186,7 +188,7 @@ function M.deduplicate_checks(checks)
 end
 
 --- Get sort priority for a check (lower = shown first).
---- @param check table check run object from statusCheckRollup
+--- @param check table check run or StatusContext object from statusCheckRollup
 --- @return number priority, string name
 local function check_sort_key(check)
 	local status, conclusion = M.normalize_check(check)
@@ -210,7 +212,8 @@ local function check_sort_key(check)
 	return priority, name
 end
 
---- Sort checks by priority: failures first, then skipped/cancelled, then in-progress, then success.
+--- Sort checks by priority: failures first, then cancelled/action-required, then skipped/neutral,
+--- then in-progress, then success, then any remaining states.
 --- Within the same priority, checks are sorted alphabetically by name.
 --- @param checks table[] statusCheckRollup array
 --- @return table[] sorted copy of checks

--- a/tests/reviewit/ui_spec.lua
+++ b/tests/reviewit/ui_spec.lua
@@ -229,10 +229,10 @@ describe("normalize_check", function()
 		assert.are.equal("", conclusion)
 	end)
 
-	it("normalizes StatusContext EXPECTED to SUCCESS", function()
+	it("normalizes StatusContext EXPECTED to PENDING", function()
 		local status, conclusion = ui.normalize_check({ context = "ci/check", state = "EXPECTED" })
-		assert.are.equal("COMPLETED", status)
-		assert.are.equal("SUCCESS", conclusion)
+		assert.are.equal("PENDING", status)
+		assert.are.equal("", conclusion)
 	end)
 
 	it("returns empty strings for unknown object", function()


### PR DESCRIPTION
## Summary

PR overview の CI STATUS セクションを改善する。check の表示順をステータス優先度順にソートし、Commit Status API (StatusContext) の表示にも対応する。

## Changes

- `sort_checks()` 関数を追加し、CI checks を優先度順にソート: failure > cancelled > skipped > in-progress > success > unknown（同一優先度内はアルファベット順）
- `normalize_check()` 関数を追加し、CheckRun (`status`/`conclusion`) と StatusContext (`state`/`context`) の両形式を統一的に処理
- `format_check_status`、`check_sort_key`、`build_checks_summary`、`build_overview_lines` を `normalize_check` 経由に変更
- StatusContext の `state` フィールド（大文字: `"SUCCESS"`, `"FAILURE"`, `"ERROR"`, `"PENDING"`, `"EXPECTED"`）を正しくマッピング

## Test plan

- [x] 既存テスト全パス (`make all`)
- [x] 新規テスト追加: `tests/reviewit/ui_spec.lua` (sort_checks 10件, normalize_check 8件, format_check_status StatusContext 4件, build_checks_summary StatusContext 1件)
- [x] 手動確認: StatusContext を使用する CI check が `?` ではなく正しいアイコンで表示されることを確認
- [x] 手動確認: CI checks が失敗 → スキップ → 成功の順に表示されることを確認

## Notes

- StatusContext の `"ERROR"` は `FAILURE` にマッピング（GitHub UI と同じ扱い）
- `normalize_check` は `status`/`conclusion` フィールドが存在する場合はそちらを優先（CheckRun と StatusContext の両方のフィールドを持つオブジェクトへの安全対応）
- StatusContext の `state` は大文字で返されるが、`.upper()` で正規化しているため大小文字に関わらず対応可能

---
🤖 Generated with [Claude Code](https://claude.ai/code)