### PR TITLE
fix: return focus to source window when closing comment float

### DIFF
--- a/lua/fude/comments.lua
+++ b/lua/fude/comments.lua
@@ -683,10 +683,13 @@ function M.next_comment()
 		return
 	end
 
-	-- Close float window if called from within one
+	-- Close float window if called from within one, but avoid closing modifiable floats (e.g. comment input)
 	local win_config = vim.api.nvim_win_get_config(0)
 	if win_config.relative and win_config.relative ~= "" then
-		vim.api.nvim_win_close(0, true)
+		local buf = vim.api.nvim_get_current_buf()
+		if not vim.bo[buf].modifiable then
+			vim.api.nvim_win_close(0, true)
+		end
 	end
 
 	local buf = vim.api.nvim_get_current_buf()
@@ -909,10 +912,13 @@ function M.prev_comment()
 		return
 	end
 
-	-- Close float window if called from within one
+	-- Close float window if called from within one, but avoid closing modifiable floats (e.g. comment input)
 	local win_config = vim.api.nvim_win_get_config(0)
 	if win_config.relative and win_config.relative ~= "" then
-		vim.api.nvim_win_close(0, true)
+		local buf = vim.api.nvim_get_current_buf()
+		if not vim.bo[buf].modifiable then
+			vim.api.nvim_win_close(0, true)
+		end
 	end
 
 	local buf = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
resolves https://github.com/flexphere/fude.nvim/issues/19

## 概要
ユーザー定義のキーマップでコメント移動する場合でも、連続して操作できるようにしました。

## 背景
`next_comment()` / `prev_comment()` API をユーザー定義のキーマップ（例: `]r`/`[r`）で呼び出した場合、コメント一覧フロートが開いたままになり、連続してコメント間を移動できませんでした。

## 変更内容
`next_comment()` / `prev_comment()` の先頭で、フロートウィンドウ内から呼ばれた場合はフロートを閉じる処理を追加しました。

## テスト方法
1. `FudeReviewStart` でプラグインを開始
2. コメントがある行でコメント一覧を表示
3. ユーザー定義のキーマップでコメント移動を連続して実行できることを確認（[c/]cと同じように移動できる）

🤖 Generated with [Claude Code](https://claude.ai/code)