### PR TITLE
feat: add /review-respond skill for PR review handling

### DIFF
--- a/.claude/skills/review-respond/SKILL.md
+++ b/.claude/skills/review-respond/SKILL.md
@@ -32,11 +32,11 @@ argument-hint: [PR番号（省略時はカレントブランチのPR）]
    - PR が見つからない場合はエラーを報告して終了する
 
 2. 未対応のレビューコメント（**行コメントのみ**）を取得する
-   ```bash
+   # 現在のユーザー(login)を取得
+   CURRENT_USER=$(gh api user --jq '.login')
+
+   # PR のレビューコメント一覧を取得
    gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
-   - `in_reply_to_id` が null のコメント = スレッドのルート（レビュー指摘）
-   - ルートコメントに対して自分（PR作成者）の返信が既にある場合は「対応済み」としてスキップ
-   - bot によるコメント（user.type == "Bot"）も対象に含める
 
 3. 未対応コメントごとに、対象コードを読み込み妥当性を分析する
    - コメントの位置情報（`path` + `line` / `original_line`、あるいは `start_line` / `original_start_line` + `line` / `original_line`、`side` / `start_side` など）から、コメントが指しているコード範囲を特定する


### PR DESCRIPTION
## Summary

develop スキルで作成した PR にレビューコメントが付いた後の対応ワークフローを追加。レビュー指摘の妥当性分析、コード修正、動作確認、コミット・返信・push までを一貫して行う。

## Changes

- `.claude/skills/review-respond/SKILL.md` を新規追加
  - Phase 1: レビューコメント取得と妥当性分析（確認必須）
  - Phase 2: コード修正と品質チェック（自律実行可）
  - Phase 3: ユーザー動作確認（確認必須）
  - Phase 4: 指摘ごとに個別コミット → `Fixed in <sha> — <説明>` 形式で返信 → push（確認必須）
- resolve は行わない（ユーザーが手動で実施）
- PR #11 の実際のレビュー対応フローをベースに設計

## Test plan

- [ ] スキルファイルの構文・フォーマット確認
- [ ] 実際のレビュー付き PR で `/review-respond` を実行して動作確認

## Notes

- `.claude/` はグローバル `.gitignore` で除外されているため `git add -f` で追加

---
🤖 Generated with [Claude Code](https://claude.ai/code)