### PR TITLE
feat: add comment navigation keymaps to overview float

### DIFF
--- a/doc/fude.txt
+++ b/doc/fude.txt
@@ -101,7 +101,8 @@ Using lazy.nvim: >lua
     Section marks are set on the left pane: `'d` (description),
     `'c` (comments). Customizable via `overview.marks`.
     Press `C` to write a new comment, `R` to refresh,
-    `<Tab>` to switch between panes, `q` to close.
+    `<Tab>` to switch between panes, `]c`/`[c` to navigate
+    review comments, `q` to close.
 
 :FudeReviewSuggest                                  *:FudeReviewSuggest*
     Suggest a code change on the current line (normal mode) or

--- a/lua/fude/ui.lua
+++ b/lua/fude/ui.lua
@@ -415,7 +415,7 @@ function M.build_overview_left_lines(pr_info, issue_comments, format_date_fn)
 
 	-- Footer
 	table.insert(lines, "")
-	table.insert(lines, " ]s/[s: sections  C: comment  R: refresh  <Tab>: switch  q: close")
+	table.insert(lines, " ]s/[s: sections  ]c/[c: comments  C: comment  R: refresh  <Tab>: switch  q: close")
 	table.insert(hl_ranges, { line = #lines - 1, hl = "Comment" })
 
 	return { lines = lines, hl_ranges = hl_ranges, sections = sections }
@@ -954,6 +954,23 @@ function M.show_overview_float(pr_info, issue_comments, opts)
 			end
 		end
 	end, { buffer = left_buf, desc = "Previous section" })
+
+	-- Comment navigation keymaps (both panes)
+	local km = config.opts.keymaps
+	for _, buf in ipairs({ left_buf, right_buf }) do
+		if km.next_comment then
+			vim.keymap.set("n", km.next_comment, function()
+				close_both()
+				require("fude.comments").next_comment()
+			end, { buffer = buf, desc = "Next comment" })
+		end
+		if km.prev_comment then
+			vim.keymap.set("n", km.prev_comment, function()
+				close_both()
+				require("fude.comments").prev_comment()
+			end, { buffer = buf, desc = "Previous comment" })
+		end
+	end
 
 	-- Keymaps for right buffer
 	vim.keymap.set("n", "q", close_both, { buffer = right_buf })


### PR DESCRIPTION
## Summary
- Overview画面（`:FudeReviewOverview`）の左右両ペインで `]c`/`[c` によるレビューコメント間ナビゲーションを有効化
- コメントビューアと同じパターンで、Overview を閉じてからコメント位置にジャンプ
- フッターにキーバインドヒント（`]c/[c: comments`）を追記

## Changes
- `lua/fude/ui.lua`: `show_overview_float` に `]c`/`[c` キーマップを追加（左右両バッファ）、フッターにヒント追記
- `doc/fude.txt`: `:FudeReviewOverview` の説明に `]c`/`[c` ナビゲーションを追記

## Test plan
- [ ] `:FudeReviewStart` → `:FudeReviewOverview` で Overview を開く
- [ ] 左ペインで `]c` を押して Overview が閉じ、次のコメント行にジャンプすることを確認
- [ ] 左ペインで `[c` を押して前のコメント行にジャンプすることを確認
- [ ] `<Tab>` で右ペインに移動後、`]c`/`[c` が同様に動作することを確認
- [ ] `auto_view_comment = true` の場合、ジャンプ後にコメントビューアが自動表示されることを確認
- [ ] 既存テストが全て pass することを確認（`make all`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)