### PR TITLE
refactor: split ui.lua and comments.lua into submodules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,12 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 - **`gh.lua`** — Async wrapper around `gh` CLI using `vim.system()`. All GitHub API calls go through `run()`/`run_json()` with callback-based async pattern. Uses `repos/{owner}/{repo}` path templates for REST API (resolved by `gh` automatically) and `gh api graphql` for GraphQL API (used by viewed file management). Supports stdin for JSON payloads (used by `create_review()`).
 - **`diff.lua`** — Local git operations (sync). Gets repo root, converts paths to repo-relative, retrieves base branch file content via `git show`, and generates file diffs. Falls back to `origin/<ref>` when local ref isn't available.
 - **`preview.lua`** — Manages the side-by-side diff preview window. Creates a scratch buffer with base branch content, opens it in a vsplit, and enables `diffthis` on both windows. Uses `noautocmd` to prevent BufEnter cascades. The `opening` flag guards against re-entrant calls.
-- **`comments.lua`** — Fetches PR review comments, builds a `comment_map[path][line]` lookup, and provides navigation (`next_comment`/`prev_comment` with wrap-around), creation (single-line and multi-line range as GitHub pending review), viewing, reply, pending review sync (`sync_pending_review()`), and review submission (`submit_as_review()` for batched GitHub reviews).
-- **`ui.lua`** — All floating window UI: comment input editor (markdown buffer with `<CR>` save to GitHub pending / `q` cancel, or `submit_on_enter` mode for immediate submit), comment viewer, PR overview window, and review event selector (`select_review_event()`). Manages extmarks (virtual text) for comment and pending indicators on lines.
+- **`comments.lua`** — Facade module re-exporting `comments/data.lua` and `comments/sync.lua`. Contains comment navigation (`next_comment`/`prev_comment`), creation, viewing, reply, and Telescope pickers (`list_comments`/`list_drafts`). `require("fude.comments")` is the public interface.
+  - **`comments/data.lua`** — Pure data functions with no state or side effects: `build_comment_map`, `find_next_comment_line`, `find_prev_comment_line`, `find_comment_by_id`, `get_comment_thread`, `parse_draft_key`, `build_submit_request`, `format_submit_result`, `build_review_comments`, `build_pending_comments_from_review`, `build_review_comment_object`, `pending_comments_to_array`, `get_comment_line_range`, `get_reply_target_id`.
+  - **`comments/sync.lua`** — GitHub API sync/submit operations: `fetch_comments`, `fetch_pending_review`, `sync_pending_review`, `submit_as_review`, `submit_drafts`. Uses lazy `require("fude.ui")` to avoid circular dependencies.
+- **`ui.lua`** — Facade module re-exporting `ui/format.lua` and `ui/extmarks.lua`. Contains floating window UI: comment input editor, comment viewer, PR overview window, reply window, and review event selector. `require("fude.ui")` is the public interface.
+  - **`ui/format.lua`** — Pure format/calculation functions with no state or vim API side effects: `calculate_float_dimensions`, `format_comments_for_display`, `normalize_check`, `format_check_status`, `deduplicate_checks`, `sort_checks`, `build_checks_summary`, `format_review_status`, `build_reviewers_list`, `build_reviewers_summary`, `calculate_overview_layout`, `calculate_comments_height`, `calculate_reply_window_dimensions`, `format_reply_comments_for_display`, `build_overview_left_lines`, `build_overview_right_lines`.
+  - **`ui/extmarks.lua`** — Extmark management: `flash_line`, `highlight_comment_lines`, `clear_comment_line_highlight`, `refresh_extmarks`, `clear_extmarks`, `clear_all_extmarks`. Uses lazy `require("fude.comments")` to avoid circular dependencies.
 - **`files.lua`** — Changed files display via Telescope picker (with diff preview and viewed state toggle via `<Tab>`) or quickfix list fallback. Shows GitHub viewed status for each file.
 - **`scope.lua`** — Review scope selection and navigation. Provides a Telescope picker (or `vim.ui.select` fallback) for choosing between full PR scope and individual commit scope, with commit index display (`[1/10]`) and current scope marker (`▶`). Supports next/prev scope navigation (`next_scope`/`prev_scope`), marking commits as reviewed via `<Tab>` in the Telescope picker (tracked locally in `state.reviewed_commits`), and statusline integration (`statusline()`). On commit scope: checks out the commit, fetches commit-specific changed files, updates gitsigns base to `sha^`, and refreshes the diff preview. On full PR scope: restores the original HEAD and re-fetches PR-wide changed files.
 - **`overview.lua`** — PR overview display: fetches extended PR info and issue-level comments, renders in a centered float with keymaps for commenting and refreshing.
@@ -50,17 +54,17 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 
 | Field | W (Write) | R (Read) |
 |-------|-----------|----------|
-| `active` | init | comments, ui, files, scope, preview, overview |
-| `pr_number` | init | comments, ui, files, scope, overview |
+| `active` | init | comments, comments/sync, ui/extmarks, files, scope, preview, overview |
+| `pr_number` | init | comments, comments/sync, ui, files, scope, overview |
 | `base_ref` | init | preview, scope |
 | `head_ref` | init | scope |
 | `pr_url` | init | ui |
 | `changed_files` | init, scope | files, scope |
-| `comments` | comments | comments, ui |
-| `comment_map` | comments | comments, ui |
-| `drafts` | comments, overview | comments, ui, overview |
-| `pending_comments` | comments | comments, ui |
-| `pending_review_id` | comments | comments |
+| `comments` | comments/sync | comments, comments/sync, ui/extmarks |
+| `comment_map` | comments/sync | comments, comments/sync, ui/extmarks |
+| `drafts` | comments, comments/sync, overview | comments, comments/sync, ui/extmarks, overview |
+| `pending_comments` | comments, comments/sync | comments, comments/sync, ui/extmarks |
+| `pending_review_id` | comments/sync | comments, comments/sync |
 | `pr_node_id` | init | init, files |
 | `viewed_files` | init, files | files, scope |
 | `preview_win` | preview | init, preview |
@@ -73,7 +77,7 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 | `original_head_sha` | init, scope | init, scope |
 | `original_head_ref` | init | init, scope |
 | `reviewed_commits` | scope | scope |
-| `ns_id` | config | ui, comments |
+| `ns_id` | config | ui/extmarks, comments |
 | `reply_window` | ui | ui |
 
 **高リスクフィールド**（多数のモジュールから参照）:

--- a/lua/fude/comments.lua
+++ b/lua/fude/comments.lua
@@ -1,446 +1,32 @@
 local M = {}
 local config = require("fude.config")
-local gh = require("fude.gh")
 local diff = require("fude.diff")
 local ui = require("fude.ui")
+local data = require("fude.comments.data")
+local sync = require("fude.comments.sync")
 
---- Build a nested lookup map from a flat array of comments.
---- Excludes comments belonging to a pending review (cannot be replied to).
---- @param comments table[] flat array of comment objects
---- @param pending_review_id number|nil review ID to exclude
---- @return table<string, table<number, table[]>> map[path][line] = {comments}
-function M.build_comment_map(comments, pending_review_id)
-	local map = {}
-	for _, c in ipairs(comments) do
-		-- Skip comments belonging to user's pending review (not yet submitted)
-		if pending_review_id and c.pull_request_review_id == pending_review_id then
-			goto continue
-		end
-		local path = c.path
-		local line = c.line or c.original_line
-		if path and line then
-			if not map[path] then
-				map[path] = {}
-			end
-			if not map[path][line] then
-				map[path][line] = {}
-			end
-			table.insert(map[path][line], c)
-		end
-		::continue::
-	end
-	return map
-end
+-- Re-export data functions (facade)
+M.build_comment_map = data.build_comment_map
+M.find_next_comment_line = data.find_next_comment_line
+M.find_prev_comment_line = data.find_prev_comment_line
+M.find_comment_by_id = data.find_comment_by_id
+M.get_comment_thread = data.get_comment_thread
+M.parse_draft_key = data.parse_draft_key
+M.build_submit_request = data.build_submit_request
+M.format_submit_result = data.format_submit_result
+M.build_review_comments = data.build_review_comments
+M.build_pending_comments_from_review = data.build_pending_comments_from_review
+M.build_review_comment_object = data.build_review_comment_object
+M.pending_comments_to_array = data.pending_comments_to_array
+M.get_comment_line_range = data.get_comment_line_range
+M.get_reply_target_id = data.get_reply_target_id
 
---- Find the next comment line after current_line, with wrap-around.
---- @param current_line number
---- @param sorted_lines number[]
---- @return number|nil
-function M.find_next_comment_line(current_line, sorted_lines)
-	if #sorted_lines == 0 then
-		return nil
-	end
-	for _, line in ipairs(sorted_lines) do
-		if line > current_line then
-			return line
-		end
-	end
-	return sorted_lines[1]
-end
-
---- Find the previous comment line before current_line, with wrap-around.
---- @param current_line number
---- @param sorted_lines number[]
---- @return number|nil
-function M.find_prev_comment_line(current_line, sorted_lines)
-	if #sorted_lines == 0 then
-		return nil
-	end
-	for i = #sorted_lines, 1, -1 do
-		if sorted_lines[i] < current_line then
-			return sorted_lines[i]
-		end
-	end
-	return sorted_lines[#sorted_lines]
-end
-
---- Find a comment by its ID in the comment map.
---- @param comment_id number
---- @param comment_map table<string, table<number, table[]>>
---- @return table|nil { path: string, line: number, comment: table }
-function M.find_comment_by_id(comment_id, comment_map)
-	for path, file_lines in pairs(comment_map) do
-		for line, cmts in pairs(file_lines) do
-			for _, c in ipairs(cmts) do
-				if c.id == comment_id then
-					return { path = path, line = tonumber(line), comment = c }
-				end
-			end
-		end
-	end
-	return nil
-end
-
---- Get all comments in a thread given any comment in the thread.
---- @param comment_id number
---- @param all_comments table[] flat array of all comments
---- @return table[] thread comments sorted by created_at
-function M.get_comment_thread(comment_id, all_comments)
-	-- Build lookup by id
-	local by_id = {}
-	for _, c in ipairs(all_comments) do
-		by_id[c.id] = c
-	end
-
-	-- Find root by following in_reply_to_id chain
-	local current = by_id[comment_id]
-	if not current then
-		return {}
-	end
-
-	while current.in_reply_to_id and by_id[current.in_reply_to_id] do
-		current = by_id[current.in_reply_to_id]
-	end
-	local root_id = current.id
-
-	-- Collect all comments in thread (root + replies)
-	local thread = { current }
-	for _, c in ipairs(all_comments) do
-		if c.id ~= root_id then
-			-- Check if this comment's chain leads to root
-			local node = c
-			while node.in_reply_to_id and by_id[node.in_reply_to_id] do
-				node = by_id[node.in_reply_to_id]
-			end
-			if node.id == root_id then
-				table.insert(thread, c)
-			end
-		end
-	end
-
-	-- Sort by created_at
-	table.sort(thread, function(a, b)
-		return (a.created_at or "") < (b.created_at or "")
-	end)
-
-	return thread
-end
-
---- Parse a draft key string into its components.
---- @param key string "path:start:end" or "reply:comment_id"
---- @return table|nil parsed key components
-function M.parse_draft_key(key)
-	if key == "issue_comment" then
-		return { type = "issue_comment" }
-	end
-	local reply_id = key:match("^reply:(%d+)$")
-	if reply_id then
-		return { type = "reply", comment_id = tonumber(reply_id) }
-	end
-	local path, sl, el = key:match("^(.+):(%d+):(%d+)$")
-	if path then
-		return { type = "comment", path = path, start_line = tonumber(sl), end_line = tonumber(el) }
-	end
-	return nil
-end
-
---- Build a submit request from a parsed draft key.
---- @param parsed table parse_draft_key() result
---- @param body string comment body
---- @param pr_number number
---- @param sha string HEAD commit SHA
---- @return table { type: "comment"|"comment_range"|"reply", args: table }
-function M.build_submit_request(parsed, body, pr_number, sha)
-	if parsed.type == "issue_comment" then
-		return { type = "issue_comment", args = { pr_number, body } }
-	end
-	if parsed.type == "reply" then
-		return { type = "reply", args = { pr_number, parsed.comment_id, body } }
-	end
-	if parsed.start_line == parsed.end_line then
-		return { type = "comment", args = { pr_number, sha, parsed.path, parsed.end_line, body } }
-	end
-	return { type = "comment_range", args = { pr_number, sha, parsed.path, parsed.start_line, parsed.end_line, body } }
-end
-
---- Format a submit result into a notification message.
---- @param succeeded number
---- @param failed number
---- @param total number
---- @return string message, number log_level
-function M.format_submit_result(succeeded, failed, total)
-	if failed == 0 then
-		return string.format("Submitted %d/%d drafts", succeeded, total), vim.log.levels.INFO
-	end
-	return string.format("Submitted %d/%d drafts (%d failed)", succeeded, total, failed), vim.log.levels.WARN
-end
-
---- Build review comments array from drafts.
---- Only "comment" type drafts can be included in a review.
---- Replies and issue_comments are excluded.
---- @param drafts table<string, string[]> draft_key -> lines
---- @return table { comments: table[], excluded: table<string, string> }
-function M.build_review_comments(drafts)
-	local comments = {}
-	local excluded = {}
-
-	for key, lines in pairs(drafts) do
-		local parsed = M.parse_draft_key(key)
-		if not parsed then
-			excluded[key] = "invalid_key"
-		elseif parsed.type == "reply" then
-			excluded[key] = "reply"
-		elseif parsed.type == "issue_comment" then
-			excluded[key] = "issue_comment"
-		elseif parsed.type == "comment" then
-			local body = table.concat(lines, "\n")
-			local comment = {
-				path = parsed.path,
-				body = body,
-				line = parsed.end_line,
-				side = "RIGHT",
-			}
-			if parsed.start_line ~= parsed.end_line then
-				comment.start_line = parsed.start_line
-				comment.start_side = "RIGHT"
-			end
-			table.insert(comments, comment)
-		end
-	end
-
-	return { comments = comments, excluded = excluded }
-end
-
---- Submit drafts as a single review.
---- If pending_comments exist (already on GitHub), submits the existing pending review.
---- Otherwise, creates a new review with local drafts.
---- @param event string "COMMENT", "APPROVE", or "REQUEST_CHANGES"
---- @param body string|nil review body (optional)
---- @param callback fun(err: string|nil, excluded_count: number)
-function M.submit_as_review(event, body, callback)
-	local state = config.state
-	if not state.active or not state.pr_number then
-		callback("Not active", 0)
-		return
-	end
-
-	-- Count excluded drafts (replies and issue_comments cannot be submitted as review)
-	local result = M.build_review_comments(state.drafts)
-	local excluded_count = vim.tbl_count(result.excluded)
-
-	-- If we have a pending review on GitHub, submit it
-	if state.pending_review_id and vim.tbl_count(state.pending_comments) > 0 then
-		gh.submit_review(state.pr_number, state.pending_review_id, event, body, function(err, _)
-			if err then
-				callback(err, excluded_count)
-				return
-			end
-
-			-- Clear pending state
-			state.pending_review_id = nil
-			state.pending_comments = {}
-
-			-- Also clear local drafts that were comment type
-			for key, _ in pairs(state.drafts) do
-				local parsed = M.parse_draft_key(key)
-				if parsed and parsed.type == "comment" then
-					state.drafts[key] = nil
-				end
-			end
-
-			ui.refresh_extmarks()
-			M.fetch_comments()
-
-			callback(nil, excluded_count)
-		end)
-		return
-	end
-
-	-- No pending review on GitHub, check local drafts
-	local sha, sha_err = gh.get_head_sha()
-	if not sha then
-		callback(sha_err or "Failed to get HEAD SHA", 0)
-		return
-	end
-
-	if #result.comments == 0 and (not body or body == "") then
-		callback("No comments to submit", excluded_count)
-		return
-	end
-
-	gh.create_review(state.pr_number, sha, body, event, result.comments, function(err, _)
-		if err then
-			callback(err, excluded_count)
-			return
-		end
-
-		-- Clear submitted drafts (only "comment" type)
-		for key, _ in pairs(state.drafts) do
-			local parsed = M.parse_draft_key(key)
-			if parsed and parsed.type == "comment" then
-				state.drafts[key] = nil
-			end
-		end
-
-		ui.refresh_extmarks()
-		M.fetch_comments()
-
-		callback(nil, excluded_count)
-	end)
-end
-
---- Submit multiple draft comments sequentially.
---- @param draft_entries table[] { draft_key, draft_lines, parsed }
---- @param callback fun(succeeded: number, failed: number)
-function M.submit_drafts(draft_entries, callback)
-	local sha, sha_err = gh.get_head_sha()
-	if not sha then
-		vim.notify("fude.nvim: " .. (sha_err or "Failed to get HEAD SHA"), vim.log.levels.ERROR)
-		callback(0, #draft_entries)
-		return
-	end
-
-	local state = config.state
-	local idx = 0
-	local succeeded, failed = 0, 0
-
-	local function submit_next()
-		idx = idx + 1
-		if idx > #draft_entries then
-			callback(succeeded, failed)
-			return
-		end
-		local entry = draft_entries[idx]
-		local body = table.concat(entry.draft_lines, "\n")
-		local req = M.build_submit_request(entry.parsed, body, state.pr_number, sha)
-
-		local api_fn
-		if req.type == "issue_comment" then
-			api_fn = gh.create_issue_comment
-		elseif req.type == "reply" then
-			api_fn = gh.reply_to_comment
-		elseif req.type == "comment_range" then
-			api_fn = gh.create_comment_range
-		else
-			api_fn = gh.create_comment
-		end
-
-		local args = vim.list_extend({}, req.args)
-		args[#args + 1] = function(err)
-			vim.schedule(function()
-				if err then
-					failed = failed + 1
-				else
-					succeeded = succeeded + 1
-					state.drafts[entry.draft_key] = nil
-				end
-				submit_next()
-			end)
-		end
-		api_fn(unpack(args))
-	end
-
-	submit_next()
-end
-
---- Fetch all PR review comments and build the lookup map.
-function M.fetch_comments()
-	local state = config.state
-	if not state.pr_number then
-		return
-	end
-
-	gh.get_pr_comments(state.pr_number, function(err, comments)
-		if err then
-			vim.notify("fude.nvim: Failed to fetch comments: " .. err, vim.log.levels.WARN)
-			return
-		end
-
-		state.comments = comments or {}
-		state.comment_map = M.build_comment_map(state.comments, state.pending_review_id)
-
-		ui.refresh_extmarks()
-		vim.notify(string.format("fude.nvim: Loaded %d comments", #state.comments), vim.log.levels.INFO)
-	end)
-end
-
---- Build pending_comments from review comments array.
---- @param comments table[] array of review comment objects from GitHub
---- @return table<string, table> map of key -> comment data
-function M.build_pending_comments_from_review(comments)
-	local result = {}
-	for _, c in ipairs(comments) do
-		local path = c.path
-		local line = c.line or c.original_line
-		local start_line = c.start_line or line
-		if path and line then
-			local key = path .. ":" .. start_line .. ":" .. line
-			result[key] = {
-				path = path,
-				body = c.body,
-				line = line,
-				side = c.side or "RIGHT",
-			}
-			if start_line ~= line then
-				result[key].start_line = start_line
-				result[key].start_side = c.start_side or "RIGHT"
-			end
-		end
-	end
-	return result
-end
-
---- Fetch existing pending review from GitHub and load into state.
-function M.fetch_pending_review()
-	local state = config.state
-	if not state.pr_number then
-		return
-	end
-
-	gh.get_reviews(state.pr_number, function(err, reviews)
-		if err then
-			vim.notify("fude.nvim: Failed to fetch reviews: " .. err, vim.log.levels.DEBUG)
-			return
-		end
-
-		-- Find pending review for current user
-		local pending_review = nil
-		for _, review in ipairs(reviews or {}) do
-			if review.state == "PENDING" then
-				pending_review = review
-				break
-			end
-		end
-
-		if not pending_review then
-			return
-		end
-
-		state.pending_review_id = pending_review.id
-
-		-- Rebuild comment_map to exclude pending review comments
-		if state.comments then
-			state.comment_map = M.build_comment_map(state.comments, state.pending_review_id)
-			ui.refresh_extmarks()
-		end
-
-		-- Fetch comments for this pending review
-		gh.get_review_comments(state.pr_number, pending_review.id, function(comments_err, comments)
-			if comments_err then
-				vim.notify("fude.nvim: Failed to fetch pending comments: " .. comments_err, vim.log.levels.DEBUG)
-				return
-			end
-
-			state.pending_comments = M.build_pending_comments_from_review(comments or {})
-			ui.refresh_extmarks()
-
-			local count = vim.tbl_count(state.pending_comments)
-			if count > 0 then
-				vim.notify(string.format("fude.nvim: Loaded %d pending comments", count), vim.log.levels.INFO)
-			end
-		end)
-	end)
-end
+-- Re-export sync functions (facade)
+M.submit_as_review = sync.submit_as_review
+M.submit_drafts = sync.submit_drafts
+M.fetch_comments = sync.fetch_comments
+M.fetch_pending_review = sync.fetch_pending_review
+M.sync_pending_review = sync.sync_pending_review
 
 --- Get comments at a specific file and line.
 --- @param rel_path string repo-relative file path
@@ -468,96 +54,6 @@ function M.get_comment_lines(rel_path)
 	end
 	table.sort(lines)
 	return lines
-end
-
---- Build a review comment object from parsed draft key components.
---- @param path string repo-relative file path
---- @param start_line number start line number
---- @param end_line number end line number
---- @param body string comment body
---- @return table review comment object for GitHub API
-function M.build_review_comment_object(path, start_line, end_line, body)
-	local comment = {
-		path = path,
-		body = body,
-		line = end_line,
-		side = "RIGHT",
-	}
-	if start_line ~= end_line then
-		comment.start_line = start_line
-		comment.start_side = "RIGHT"
-	end
-	return comment
-end
-
---- Convert pending_comments table to array of review comment objects.
---- @param pending_comments table<string, table> map of key -> comment data
---- @return table[] array of review comment objects
-function M.pending_comments_to_array(pending_comments)
-	local result = {}
-	for _, comment_data in pairs(pending_comments) do
-		table.insert(result, comment_data)
-	end
-	return result
-end
-
---- Sync pending comments to GitHub as a pending review.
---- This will delete any existing pending review and create a new one with all comments.
---- @param callback fun(err: string|nil)
-function M.sync_pending_review(callback)
-	local state = config.state
-	if not state.active or not state.pr_number then
-		callback("Not active")
-		return
-	end
-
-	local sha, sha_err = gh.get_head_sha()
-	if not sha then
-		callback(sha_err or "Failed to get HEAD SHA")
-		return
-	end
-
-	local comments_array = M.pending_comments_to_array(state.pending_comments)
-
-	-- If no pending comments, just delete any existing pending review
-	if #comments_array == 0 then
-		if state.pending_review_id then
-			gh.delete_review(state.pr_number, state.pending_review_id, function(err)
-				if not err then
-					state.pending_review_id = nil
-				end
-				callback(err)
-			end)
-		else
-			callback(nil)
-		end
-		return
-	end
-
-	local function create_new_review()
-		gh.create_pending_review(state.pr_number, sha, comments_array, function(err, data)
-			if err then
-				callback(err)
-				return
-			end
-			state.pending_review_id = data and data.id
-			callback(nil)
-		end)
-	end
-
-	-- If there's an existing pending review, delete it first
-	if state.pending_review_id then
-		gh.delete_review(state.pr_number, state.pending_review_id, function(err)
-			if err then
-				-- Ignore delete error (review might already be gone)
-				vim.notify("fude.nvim: Note: " .. err, vim.log.levels.DEBUG)
-			end
-			state.pending_review_id = nil
-			create_new_review()
-		end)
-	else
-		create_new_review()
-	end
 end
 
 --- Create a new comment on the current line or visual selection.
@@ -590,13 +86,13 @@ function M.create_comment(is_visual)
 	local existing = state.pending_comments[pending_key]
 	local initial_lines = existing and vim.split(existing.body, "\n") or nil
 
-	ui.open_comment_input(function(body)
-		if body then
+	ui.open_comment_input(function(comment_body)
+		if comment_body then
 			-- <CR> pressed: save as pending review on GitHub
-			local comment_obj = M.build_review_comment_object(rel_path, start_line, end_line, body)
+			local comment_obj = data.build_review_comment_object(rel_path, start_line, end_line, comment_body)
 			state.pending_comments[pending_key] = comment_obj
 
-			M.sync_pending_review(function(err)
+			sync.sync_pending_review(function(err)
 				vim.schedule(function()
 					if err then
 						vim.notify("fude.nvim: Failed to save pending: " .. err, vim.log.levels.ERROR)
@@ -619,15 +115,6 @@ function M.create_comment(is_visual)
 			ui.refresh_extmarks()
 		end,
 	})
-end
-
---- Get the line range for a comment (start_line to line).
---- @param comment table comment object from GitHub API
---- @return number start_line, number end_line
-function M.get_comment_line_range(comment)
-	local end_line = tonumber(comment.line) or tonumber(comment.original_line) or 1
-	local start_line = tonumber(comment.start_line) or end_line
-	return start_line, end_line
 end
 
 --- View comments on the current line.
@@ -653,22 +140,9 @@ function M.view_comments()
 	end
 
 	-- Get the line range from the first comment (all comments at this line share the same range)
-	local start_line, end_line = M.get_comment_line_range(comments[1])
+	local start_line, end_line = data.get_comment_line_range(comments[1])
 
 	ui.show_comments_float(comments, { source_buf = buf, source_start_line = start_line, source_end_line = end_line })
-end
-
---- Get the reply target ID for a comment.
---- GitHub API doesn't allow replying to replies, so we need to find the top-level comment.
---- @param comment_id number the comment ID
---- @param comment_map table the comment map
---- @return number the ID to use for reply (either original or in_reply_to_id)
-function M.get_reply_target_id(comment_id, comment_map)
-	local found = M.find_comment_by_id(comment_id, comment_map)
-	if found and found.comment.in_reply_to_id then
-		return found.comment.in_reply_to_id
-	end
-	return comment_id
 end
 
 --- Reply to the most recent comment on the current line.
@@ -702,28 +176,29 @@ function M.reply_to_comment(comment_id)
 	end
 
 	-- Get the full thread for this comment
-	local thread = M.get_comment_thread(comment_id, state.comments or {})
+	local thread = data.get_comment_thread(comment_id, state.comments or {})
 	if #thread == 0 then
 		vim.notify("fude.nvim: Comment not found", vim.log.levels.WARN)
 		return
 	end
 
 	-- GitHub API doesn't allow replying to replies, find top-level comment
-	local reply_target_id = M.get_reply_target_id(comment_id, state.comment_map or {})
+	local reply_target_id = data.get_reply_target_id(comment_id, state.comment_map or {})
 
 	local draft_key = "reply:" .. reply_target_id
+	local gh = require("fude.gh")
 
 	ui.open_reply_window(thread, {
-		on_submit = function(body)
+		on_submit = function(reply_body)
 			state.drafts[draft_key] = nil
 
-			gh.reply_to_comment(state.pr_number, reply_target_id, body, function(err, _)
+			gh.reply_to_comment(state.pr_number, reply_target_id, reply_body, function(err, _)
 				if err then
 					vim.notify("fude.nvim: Reply failed: " .. err, vim.log.levels.ERROR)
 					return
 				end
 				vim.notify("fude.nvim: Reply posted", vim.log.levels.INFO)
-				M.fetch_comments()
+				sync.fetch_comments()
 			end)
 		end,
 		on_cancel = function(lines)
@@ -759,7 +234,7 @@ function M.next_comment()
 
 	local current_line = vim.fn.line(".")
 	local comment_lines = M.get_comment_lines(rel_path)
-	local target = M.find_next_comment_line(current_line, comment_lines)
+	local target = data.find_next_comment_line(current_line, comment_lines)
 	if target then
 		vim.api.nvim_win_set_cursor(0, { target, 0 })
 		if config.opts.auto_view_comment then
@@ -936,13 +411,13 @@ function M.suggest_change(is_visual)
 	local initial_lines = existing and vim.split(existing.body, "\n") or suggestion_lines
 	local cursor_pos = existing and nil or { 2, 0 }
 
-	ui.open_comment_input(function(body)
-		if body then
+	ui.open_comment_input(function(comment_body)
+		if comment_body then
 			-- <CR> pressed: save as pending review on GitHub
-			local comment_obj = M.build_review_comment_object(rel_path, start_line, end_line, body)
+			local comment_obj = data.build_review_comment_object(rel_path, start_line, end_line, comment_body)
 			state.pending_comments[pending_key] = comment_obj
 
-			M.sync_pending_review(function(err)
+			sync.sync_pending_review(function(err)
 				vim.schedule(function()
 					if err then
 						vim.notify("fude.nvim: Failed to save pending: " .. err, vim.log.levels.ERROR)
@@ -992,7 +467,7 @@ function M.prev_comment()
 
 	local current_line = vim.fn.line(".")
 	local comment_lines = M.get_comment_lines(rel_path)
-	local target = M.find_prev_comment_line(current_line, comment_lines)
+	local target = data.find_prev_comment_line(current_line, comment_lines)
 	if target then
 		vim.api.nvim_win_set_cursor(0, { target, 0 })
 		if config.opts.auto_view_comment then
@@ -1035,7 +510,7 @@ function M.list_drafts()
 
 	local entries = {}
 	for key, draft_lines in pairs(state.drafts) do
-		local parsed = M.parse_draft_key(key)
+		local parsed = data.parse_draft_key(key)
 		if not parsed then
 			goto continue
 		end
@@ -1060,7 +535,7 @@ function M.list_drafts()
 				display = detail,
 			})
 		elseif parsed.type == "reply" then
-			local found = M.find_comment_by_id(parsed.comment_id, state.comment_map or {})
+			local found = data.find_comment_by_id(parsed.comment_id, state.comment_map or {})
 			local reply_path = found and found.path
 			local reply_line = found and found.line
 			local loc = reply_path and string.format("%s:%d", reply_path, reply_line or 1) or "reply:" .. parsed.comment_id
@@ -1138,7 +613,7 @@ function M.list_drafts()
 					local targets = #multi > 0 and multi or entries
 					local to_submit = {}
 					for _, entry in ipairs(targets) do
-						local parsed = M.parse_draft_key(entry.draft_key)
+						local parsed = data.parse_draft_key(entry.draft_key)
 						if parsed then
 							table.insert(to_submit, {
 								draft_key = entry.draft_key,
@@ -1157,11 +632,11 @@ function M.list_drafts()
 						if choice ~= "Yes" then
 							return
 						end
-						M.submit_drafts(to_submit, function(succeeded, failed)
-							local msg, level = M.format_submit_result(succeeded, failed, #to_submit)
+						sync.submit_drafts(to_submit, function(succeeded, failed)
+							local msg, level = data.format_submit_result(succeeded, failed, #to_submit)
 							vim.notify("fude.nvim: " .. msg, level)
 							ui.refresh_extmarks()
-							M.fetch_comments()
+							sync.fetch_comments()
 						end)
 					end)
 				end)
@@ -1172,8 +647,8 @@ function M.list_drafts()
 						if not event then
 							return
 						end
-						ui.open_comment_input(function(body)
-							M.submit_as_review(event, body, function(err, excluded_count)
+						ui.open_comment_input(function(review_body)
+							sync.submit_as_review(event, review_body, function(err, excluded_count)
 								if err then
 									vim.notify("fude.nvim: " .. err, vim.log.levels.ERROR)
 									return

--- a/lua/fude/comments/data.lua
+++ b/lua/fude/comments/data.lua
@@ -1,0 +1,289 @@
+local M = {}
+
+--- Build a nested lookup map from a flat array of comments.
+--- Excludes comments belonging to a pending review (cannot be replied to).
+--- @param comments table[] flat array of comment objects
+--- @param pending_review_id number|nil review ID to exclude
+--- @return table<string, table<number, table[]>> map[path][line] = {comments}
+function M.build_comment_map(comments, pending_review_id)
+	local map = {}
+	for _, c in ipairs(comments) do
+		-- Skip comments belonging to user's pending review (not yet submitted)
+		if pending_review_id and c.pull_request_review_id == pending_review_id then
+			goto continue
+		end
+		local path = c.path
+		local line = c.line or c.original_line
+		if path and line then
+			if not map[path] then
+				map[path] = {}
+			end
+			if not map[path][line] then
+				map[path][line] = {}
+			end
+			table.insert(map[path][line], c)
+		end
+		::continue::
+	end
+	return map
+end
+
+--- Find the next comment line after current_line, with wrap-around.
+--- @param current_line number
+--- @param sorted_lines number[]
+--- @return number|nil
+function M.find_next_comment_line(current_line, sorted_lines)
+	if #sorted_lines == 0 then
+		return nil
+	end
+	for _, line in ipairs(sorted_lines) do
+		if line > current_line then
+			return line
+		end
+	end
+	return sorted_lines[1]
+end
+
+--- Find the previous comment line before current_line, with wrap-around.
+--- @param current_line number
+--- @param sorted_lines number[]
+--- @return number|nil
+function M.find_prev_comment_line(current_line, sorted_lines)
+	if #sorted_lines == 0 then
+		return nil
+	end
+	for i = #sorted_lines, 1, -1 do
+		if sorted_lines[i] < current_line then
+			return sorted_lines[i]
+		end
+	end
+	return sorted_lines[#sorted_lines]
+end
+
+--- Find a comment by its ID in the comment map.
+--- @param comment_id number
+--- @param comment_map table<string, table<number, table[]>>
+--- @return table|nil { path: string, line: number, comment: table }
+function M.find_comment_by_id(comment_id, comment_map)
+	for path, file_lines in pairs(comment_map) do
+		for line, cmts in pairs(file_lines) do
+			for _, c in ipairs(cmts) do
+				if c.id == comment_id then
+					return { path = path, line = tonumber(line), comment = c }
+				end
+			end
+		end
+	end
+	return nil
+end
+
+--- Get all comments in a thread given any comment in the thread.
+--- @param comment_id number
+--- @param all_comments table[] flat array of all comments
+--- @return table[] thread comments sorted by created_at
+function M.get_comment_thread(comment_id, all_comments)
+	-- Build lookup by id
+	local by_id = {}
+	for _, c in ipairs(all_comments) do
+		by_id[c.id] = c
+	end
+
+	-- Find root by following in_reply_to_id chain
+	local current = by_id[comment_id]
+	if not current then
+		return {}
+	end
+
+	while current.in_reply_to_id and by_id[current.in_reply_to_id] do
+		current = by_id[current.in_reply_to_id]
+	end
+	local root_id = current.id
+
+	-- Collect all comments in thread (root + replies)
+	local thread = { current }
+	for _, c in ipairs(all_comments) do
+		if c.id ~= root_id then
+			-- Check if this comment's chain leads to root
+			local node = c
+			while node.in_reply_to_id and by_id[node.in_reply_to_id] do
+				node = by_id[node.in_reply_to_id]
+			end
+			if node.id == root_id then
+				table.insert(thread, c)
+			end
+		end
+	end
+
+	-- Sort by created_at
+	table.sort(thread, function(a, b)
+		return (a.created_at or "") < (b.created_at or "")
+	end)
+
+	return thread
+end
+
+--- Parse a draft key string into its components.
+--- @param key string "path:start:end" or "reply:comment_id"
+--- @return table|nil parsed key components
+function M.parse_draft_key(key)
+	if key == "issue_comment" then
+		return { type = "issue_comment" }
+	end
+	local reply_id = key:match("^reply:(%d+)$")
+	if reply_id then
+		return { type = "reply", comment_id = tonumber(reply_id) }
+	end
+	local path, sl, el = key:match("^(.+):(%d+):(%d+)$")
+	if path then
+		return { type = "comment", path = path, start_line = tonumber(sl), end_line = tonumber(el) }
+	end
+	return nil
+end
+
+--- Build a submit request from a parsed draft key.
+--- @param parsed table parse_draft_key() result
+--- @param body string comment body
+--- @param pr_number number
+--- @param sha string HEAD commit SHA
+--- @return table { type: "comment"|"comment_range"|"reply", args: table }
+function M.build_submit_request(parsed, body, pr_number, sha)
+	if parsed.type == "issue_comment" then
+		return { type = "issue_comment", args = { pr_number, body } }
+	end
+	if parsed.type == "reply" then
+		return { type = "reply", args = { pr_number, parsed.comment_id, body } }
+	end
+	if parsed.start_line == parsed.end_line then
+		return { type = "comment", args = { pr_number, sha, parsed.path, parsed.end_line, body } }
+	end
+	return { type = "comment_range", args = { pr_number, sha, parsed.path, parsed.start_line, parsed.end_line, body } }
+end
+
+--- Format a submit result into a notification message.
+--- @param succeeded number
+--- @param failed number
+--- @param total number
+--- @return string message, number log_level
+function M.format_submit_result(succeeded, failed, total)
+	if failed == 0 then
+		return string.format("Submitted %d/%d drafts", succeeded, total), vim.log.levels.INFO
+	end
+	return string.format("Submitted %d/%d drafts (%d failed)", succeeded, total, failed), vim.log.levels.WARN
+end
+
+--- Build review comments array from drafts.
+--- Only "comment" type drafts can be included in a review.
+--- Replies and issue_comments are excluded.
+--- @param drafts table<string, string[]> draft_key -> lines
+--- @return table { comments: table[], excluded: table<string, string> }
+function M.build_review_comments(drafts)
+	local comments = {}
+	local excluded = {}
+
+	for key, lines in pairs(drafts) do
+		local parsed = M.parse_draft_key(key)
+		if not parsed then
+			excluded[key] = "invalid_key"
+		elseif parsed.type == "reply" then
+			excluded[key] = "reply"
+		elseif parsed.type == "issue_comment" then
+			excluded[key] = "issue_comment"
+		elseif parsed.type == "comment" then
+			local body = table.concat(lines, "\n")
+			local comment = {
+				path = parsed.path,
+				body = body,
+				line = parsed.end_line,
+				side = "RIGHT",
+			}
+			if parsed.start_line ~= parsed.end_line then
+				comment.start_line = parsed.start_line
+				comment.start_side = "RIGHT"
+			end
+			table.insert(comments, comment)
+		end
+	end
+
+	return { comments = comments, excluded = excluded }
+end
+
+--- Build pending_comments from review comments array.
+--- @param comments table[] array of review comment objects from GitHub
+--- @return table<string, table> map of key -> comment data
+function M.build_pending_comments_from_review(comments)
+	local result = {}
+	for _, c in ipairs(comments) do
+		local path = c.path
+		local line = c.line or c.original_line
+		local start_line = c.start_line or line
+		if path and line then
+			local key = path .. ":" .. start_line .. ":" .. line
+			result[key] = {
+				path = path,
+				body = c.body,
+				line = line,
+				side = c.side or "RIGHT",
+			}
+			if start_line ~= line then
+				result[key].start_line = start_line
+				result[key].start_side = c.start_side or "RIGHT"
+			end
+		end
+	end
+	return result
+end
+
+--- Build a review comment object from parsed draft key components.
+--- @param path string repo-relative file path
+--- @param start_line number start line number
+--- @param end_line number end line number
+--- @param body string comment body
+--- @return table review comment object for GitHub API
+function M.build_review_comment_object(path, start_line, end_line, body)
+	local comment = {
+		path = path,
+		body = body,
+		line = end_line,
+		side = "RIGHT",
+	}
+	if start_line ~= end_line then
+		comment.start_line = start_line
+		comment.start_side = "RIGHT"
+	end
+	return comment
+end
+
+--- Convert pending_comments table to array of review comment objects.
+--- @param pending_comments table<string, table> map of key -> comment data
+--- @return table[] array of review comment objects
+function M.pending_comments_to_array(pending_comments)
+	local result = {}
+	for _, comment_data in pairs(pending_comments) do
+		table.insert(result, comment_data)
+	end
+	return result
+end
+
+--- Get the line range for a comment (start_line to line).
+--- @param comment table comment object from GitHub API
+--- @return number start_line, number end_line
+function M.get_comment_line_range(comment)
+	local end_line = tonumber(comment.line) or tonumber(comment.original_line) or 1
+	local start_line = tonumber(comment.start_line) or end_line
+	return start_line, end_line
+end
+
+--- Get the reply target ID for a comment.
+--- GitHub API doesn't allow replying to replies, so we need to find the top-level comment.
+--- @param comment_id number the comment ID
+--- @param comment_map table the comment map
+--- @return number the ID to use for reply (either original or in_reply_to_id)
+function M.get_reply_target_id(comment_id, comment_map)
+	local found = M.find_comment_by_id(comment_id, comment_map)
+	if found and found.comment.in_reply_to_id then
+		return found.comment.in_reply_to_id
+	end
+	return comment_id
+end
+
+return M

--- a/lua/fude/comments/sync.lua
+++ b/lua/fude/comments/sync.lua
@@ -1,0 +1,280 @@
+local M = {}
+local config = require("fude.config")
+local gh = require("fude.gh")
+local data = require("fude.comments.data")
+
+--- Submit drafts as a single review.
+--- If pending_comments exist (already on GitHub), submits the existing pending review.
+--- Otherwise, creates a new review with local drafts.
+--- @param event string "COMMENT", "APPROVE", or "REQUEST_CHANGES"
+--- @param body string|nil review body (optional)
+--- @param callback fun(err: string|nil, excluded_count: number)
+function M.submit_as_review(event, body, callback)
+	local state = config.state
+	if not state.active or not state.pr_number then
+		callback("Not active", 0)
+		return
+	end
+
+	-- Count excluded drafts (replies and issue_comments cannot be submitted as review)
+	local result = data.build_review_comments(state.drafts)
+	local excluded_count = vim.tbl_count(result.excluded)
+
+	-- If we have a pending review on GitHub, submit it
+	if state.pending_review_id and vim.tbl_count(state.pending_comments) > 0 then
+		gh.submit_review(state.pr_number, state.pending_review_id, event, body, function(err, _)
+			if err then
+				callback(err, excluded_count)
+				return
+			end
+
+			-- Clear pending state
+			state.pending_review_id = nil
+			state.pending_comments = {}
+
+			-- Also clear local drafts that were comment type
+			for key, _ in pairs(state.drafts) do
+				local parsed = data.parse_draft_key(key)
+				if parsed and parsed.type == "comment" then
+					state.drafts[key] = nil
+				end
+			end
+
+			vim.schedule(function()
+				require("fude.ui").refresh_extmarks()
+			end)
+			M.fetch_comments()
+
+			callback(nil, excluded_count)
+		end)
+		return
+	end
+
+	-- No pending review on GitHub, check local drafts
+	local sha, sha_err = gh.get_head_sha()
+	if not sha then
+		callback(sha_err or "Failed to get HEAD SHA", 0)
+		return
+	end
+
+	if #result.comments == 0 and (not body or body == "") then
+		callback("No comments to submit", excluded_count)
+		return
+	end
+
+	gh.create_review(state.pr_number, sha, body, event, result.comments, function(err, _)
+		if err then
+			callback(err, excluded_count)
+			return
+		end
+
+		-- Clear submitted drafts (only "comment" type)
+		for key, _ in pairs(state.drafts) do
+			local parsed = data.parse_draft_key(key)
+			if parsed and parsed.type == "comment" then
+				state.drafts[key] = nil
+			end
+		end
+
+		vim.schedule(function()
+			require("fude.ui").refresh_extmarks()
+		end)
+		M.fetch_comments()
+
+		callback(nil, excluded_count)
+	end)
+end
+
+--- Submit multiple draft comments sequentially.
+--- @param draft_entries table[] { draft_key, draft_lines, parsed }
+--- @param callback fun(succeeded: number, failed: number)
+function M.submit_drafts(draft_entries, callback)
+	local sha, sha_err = gh.get_head_sha()
+	if not sha then
+		vim.notify("fude.nvim: " .. (sha_err or "Failed to get HEAD SHA"), vim.log.levels.ERROR)
+		callback(0, #draft_entries)
+		return
+	end
+
+	local state = config.state
+	local idx = 0
+	local succeeded, failed = 0, 0
+
+	local function submit_next()
+		idx = idx + 1
+		if idx > #draft_entries then
+			callback(succeeded, failed)
+			return
+		end
+		local entry = draft_entries[idx]
+		local entry_body = table.concat(entry.draft_lines, "\n")
+		local req = data.build_submit_request(entry.parsed, entry_body, state.pr_number, sha)
+
+		local api_fn
+		if req.type == "issue_comment" then
+			api_fn = gh.create_issue_comment
+		elseif req.type == "reply" then
+			api_fn = gh.reply_to_comment
+		elseif req.type == "comment_range" then
+			api_fn = gh.create_comment_range
+		else
+			api_fn = gh.create_comment
+		end
+
+		local args = vim.list_extend({}, req.args)
+		args[#args + 1] = function(err)
+			vim.schedule(function()
+				if err then
+					failed = failed + 1
+				else
+					succeeded = succeeded + 1
+					state.drafts[entry.draft_key] = nil
+				end
+				submit_next()
+			end)
+		end
+		api_fn(unpack(args))
+	end
+
+	submit_next()
+end
+
+--- Fetch all PR review comments and build the lookup map.
+function M.fetch_comments()
+	local state = config.state
+	if not state.pr_number then
+		return
+	end
+
+	gh.get_pr_comments(state.pr_number, function(err, comments)
+		if err then
+			vim.notify("fude.nvim: Failed to fetch comments: " .. err, vim.log.levels.WARN)
+			return
+		end
+
+		state.comments = comments or {}
+		state.comment_map = data.build_comment_map(state.comments, state.pending_review_id)
+
+		vim.schedule(function()
+			require("fude.ui").refresh_extmarks()
+		end)
+		vim.notify(string.format("fude.nvim: Loaded %d comments", #state.comments), vim.log.levels.INFO)
+	end)
+end
+
+--- Fetch existing pending review from GitHub and load into state.
+function M.fetch_pending_review()
+	local state = config.state
+	if not state.pr_number then
+		return
+	end
+
+	gh.get_reviews(state.pr_number, function(err, reviews)
+		if err then
+			vim.notify("fude.nvim: Failed to fetch reviews: " .. err, vim.log.levels.DEBUG)
+			return
+		end
+
+		-- Find pending review for current user
+		local pending_review = nil
+		for _, review in ipairs(reviews or {}) do
+			if review.state == "PENDING" then
+				pending_review = review
+				break
+			end
+		end
+
+		if not pending_review then
+			return
+		end
+
+		state.pending_review_id = pending_review.id
+
+		-- Rebuild comment_map to exclude pending review comments
+		if state.comments then
+			state.comment_map = data.build_comment_map(state.comments, state.pending_review_id)
+			vim.schedule(function()
+				require("fude.ui").refresh_extmarks()
+			end)
+		end
+
+		-- Fetch comments for this pending review
+		gh.get_review_comments(state.pr_number, pending_review.id, function(comments_err, comments)
+			if comments_err then
+				vim.notify("fude.nvim: Failed to fetch pending comments: " .. comments_err, vim.log.levels.DEBUG)
+				return
+			end
+
+			state.pending_comments = data.build_pending_comments_from_review(comments or {})
+			vim.schedule(function()
+				require("fude.ui").refresh_extmarks()
+			end)
+
+			local count = vim.tbl_count(state.pending_comments)
+			if count > 0 then
+				vim.notify(string.format("fude.nvim: Loaded %d pending comments", count), vim.log.levels.INFO)
+			end
+		end)
+	end)
+end
+
+--- Sync pending comments to GitHub as a pending review.
+--- This will delete any existing pending review and create a new one with all comments.
+--- @param callback fun(err: string|nil)
+function M.sync_pending_review(callback)
+	local state = config.state
+	if not state.active or not state.pr_number then
+		callback("Not active")
+		return
+	end
+
+	local sha, sha_err = gh.get_head_sha()
+	if not sha then
+		callback(sha_err or "Failed to get HEAD SHA")
+		return
+	end
+
+	local comments_array = data.pending_comments_to_array(state.pending_comments)
+
+	-- If no pending comments, just delete any existing pending review
+	if #comments_array == 0 then
+		if state.pending_review_id then
+			gh.delete_review(state.pr_number, state.pending_review_id, function(err)
+				if not err then
+					state.pending_review_id = nil
+				end
+				callback(err)
+			end)
+		else
+			callback(nil)
+		end
+		return
+	end
+
+	local function create_new_review()
+		gh.create_pending_review(state.pr_number, sha, comments_array, function(err, review_data)
+			if err then
+				callback(err)
+				return
+			end
+			state.pending_review_id = review_data and review_data.id
+			callback(nil)
+		end)
+	end
+
+	-- If there's an existing pending review, delete it first
+	if state.pending_review_id then
+		gh.delete_review(state.pr_number, state.pending_review_id, function(err)
+			if err then
+				-- Ignore delete error (review might already be gone)
+				vim.notify("fude.nvim: Note: " .. err, vim.log.levels.DEBUG)
+			end
+			state.pending_review_id = nil
+			create_new_review()
+		end)
+	else
+		create_new_review()
+	end
+end
+
+return M

--- a/lua/fude/ui.lua
+++ b/lua/fude/ui.lua
@@ -1,21 +1,35 @@
 local M = {}
 local config = require("fude.config")
+local format = require("fude.ui.format")
+local extmarks = require("fude.ui.extmarks")
 
 local ref_ns = vim.api.nvim_create_namespace("fude_refs")
 
---- Normalize newlines by converting CRLF and CR to LF.
---- @param s string|nil input string
---- @return string normalized string
-local function normalize_newlines(s)
-	return (s or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
-end
+-- Re-export format functions (facade)
+M.calculate_float_dimensions = format.calculate_float_dimensions
+M.format_comments_for_display = format.format_comments_for_display
+M.normalize_check = format.normalize_check
+M.format_check_status = format.format_check_status
+M.deduplicate_checks = format.deduplicate_checks
+M.sort_checks = format.sort_checks
+M.build_checks_summary = format.build_checks_summary
+M.format_review_status = format.format_review_status
+M.build_reviewers_list = format.build_reviewers_list
+M.build_reviewers_summary = format.build_reviewers_summary
+M.calculate_overview_layout = format.calculate_overview_layout
+M.calculate_comments_height = format.calculate_comments_height
+M.calculate_reply_window_dimensions = format.calculate_reply_window_dimensions
+M.format_reply_comments_for_display = format.format_reply_comments_for_display
+M.build_overview_left_lines = format.build_overview_left_lines
+M.build_overview_right_lines = format.build_overview_right_lines
 
---- Get the namespace ID for flash/highlight extmarks.
---- Uses config.state.ns_id so existing cleanup paths (clear_extmarks, clear_all_extmarks) cover these.
---- @return number
-local function get_flash_ns()
-	return config.state.ns_id or vim.api.nvim_create_namespace("fude")
-end
+-- Re-export extmark functions (facade)
+M.flash_line = extmarks.flash_line
+M.highlight_comment_lines = extmarks.highlight_comment_lines
+M.clear_comment_line_highlight = extmarks.clear_comment_line_highlight
+M.refresh_extmarks = extmarks.refresh_extmarks
+M.clear_extmarks = extmarks.clear_extmarks
+M.clear_all_extmarks = extmarks.clear_all_extmarks
 
 --- Get repository base URL (e.g. "https://github.com/owner/repo").
 --- @param pr_url string|nil PR URL to extract from
@@ -90,713 +104,6 @@ local function setup_github_refs(buf, repo_url, line_urls)
 	end, { buffer = buf, desc = "Open GitHub reference" })
 end
 
---- Flash highlight a line temporarily.
---- @param line number 1-indexed line number
-function M.flash_line(line)
-	local buf = vim.api.nvim_get_current_buf()
-	local ns = get_flash_ns()
-	local flash_opts = config.opts.flash or {}
-	local duration = flash_opts.duration or 200
-	local hl_group = flash_opts.hl_group or "Visual"
-
-	local extmark_id = vim.api.nvim_buf_set_extmark(buf, ns, line - 1, 0, {
-		line_hl_group = hl_group,
-		priority = 100,
-	})
-
-	vim.defer_fn(function()
-		pcall(vim.api.nvim_buf_del_extmark, buf, ns, extmark_id)
-	end, duration)
-end
-
--- Store current comment line highlight info
-local comment_line_highlight = {
-	buf = nil,
-	extmark_ids = {},
-}
-
---- Highlight lines persistently (for comment viewing).
---- @param buf number buffer handle
---- @param start_line number 1-indexed start line number
---- @param end_line number 1-indexed end line number
-function M.highlight_comment_lines(buf, start_line, end_line)
-	M.clear_comment_line_highlight()
-
-	-- Ensure line numbers are valid
-	start_line = tonumber(start_line)
-	end_line = tonumber(end_line)
-	if not start_line or not end_line then
-		return
-	end
-
-	local ns = get_flash_ns()
-	local flash_opts = config.opts.flash or {}
-	local hl_group = flash_opts.hl_group or "Visual"
-
-	comment_line_highlight.buf = buf
-	comment_line_highlight.extmark_ids = {}
-
-	for line = start_line, end_line do
-		local extmark_id = vim.api.nvim_buf_set_extmark(buf, ns, line - 1, 0, {
-			line_hl_group = hl_group,
-			priority = 100,
-		})
-		table.insert(comment_line_highlight.extmark_ids, extmark_id)
-	end
-end
-
---- Clear the persistent comment line highlight.
-function M.clear_comment_line_highlight()
-	if comment_line_highlight.buf then
-		local ns = get_flash_ns()
-		for _, extmark_id in ipairs(comment_line_highlight.extmark_ids) do
-			pcall(vim.api.nvim_buf_del_extmark, comment_line_highlight.buf, ns, extmark_id)
-		end
-	end
-	comment_line_highlight.buf = nil
-	comment_line_highlight.extmark_ids = {}
-end
-
---- Calculate centered float window dimensions from percentage-based sizes.
---- @param columns number screen width
---- @param screen_lines number screen height
---- @param pct_w number width percentage (0-100)
---- @param pct_h number height percentage (0-100)
---- @return table { width: number, height: number, row: number, col: number }
-function M.calculate_float_dimensions(columns, screen_lines, pct_w, pct_h)
-	local width = math.floor(columns * pct_w / 100)
-	local height = math.floor(screen_lines * pct_h / 100)
-	local row = math.floor((screen_lines - height) / 2)
-	local col = math.floor((columns - width) / 2)
-	return { width = width, height = height, row = row, col = col }
-end
-
---- Format comment objects into display lines and highlight ranges.
---- @param comments table[] list of comment objects
---- @param format_date_fn fun(s: string): string
---- @return table { lines: string[], hl_ranges: table[] }
-function M.format_comments_for_display(comments, format_date_fn)
-	local lines = {}
-	local hl_ranges = {}
-	for i, comment in ipairs(comments) do
-		local author = comment.user and comment.user.login or "unknown"
-		local created = format_date_fn(comment.created_at)
-		local header = string.format("@%s  %s", author, created)
-		table.insert(lines, header)
-		table.insert(hl_ranges, { line = #lines - 1, hl = "Title" })
-		local comment_body = normalize_newlines(comment.body)
-		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
-			table.insert(lines, body_line)
-		end
-		if i < #comments then
-			table.insert(lines, "")
-			table.insert(lines, string.rep("-", 40))
-			table.insert(lines, "")
-		end
-	end
-	return { lines = lines, hl_ranges = hl_ranges }
-end
-
---- Normalize check fields into a consistent (status, conclusion) pair.
---- Handles both CheckRun (status/conclusion) and StatusContext (state) objects.
---- @param check table check run or status context object
---- @return string status, string conclusion
-function M.normalize_check(check)
-	-- CheckRun: has status/conclusion fields
-	if check.status or check.conclusion then
-		return check.status or "", check.conclusion or ""
-	end
-
-	-- StatusContext: has state field (uppercase: "SUCCESS", "FAILURE", "PENDING", "ERROR", "EXPECTED")
-	local state = (check.state or ""):upper()
-	if state == "SUCCESS" then
-		return "COMPLETED", "SUCCESS"
-	elseif state == "EXPECTED" then
-		return "PENDING", ""
-	elseif state == "FAILURE" then
-		return "COMPLETED", "FAILURE"
-	elseif state == "ERROR" then
-		return "COMPLETED", "FAILURE"
-	elseif state == "PENDING" then
-		return "PENDING", ""
-	end
-
-	return "", ""
-end
-
---- Map check conclusion/status to display symbol and highlight group.
---- @param check table check run or status context object from statusCheckRollup
---- @return string symbol, string hl_group
-function M.format_check_status(check)
-	local status, conclusion = M.normalize_check(check)
-
-	-- Not yet completed
-	if status == "IN_PROGRESS" or status == "QUEUED" or status == "PENDING" then
-		return "●", "DiagnosticWarn"
-	end
-
-	-- Completed with conclusion
-	if conclusion == "SUCCESS" then
-		return "✓", "DiagnosticOk"
-	elseif conclusion == "FAILURE" or conclusion == "TIMED_OUT" or conclusion == "STARTUP_FAILURE" then
-		return "✗", "DiagnosticError"
-	elseif conclusion == "NEUTRAL" or conclusion == "SKIPPED" then
-		return "-", "Comment"
-	elseif conclusion == "CANCELLED" or conclusion == "ACTION_REQUIRED" then
-		return "!", "DiagnosticWarn"
-	end
-
-	return "?", "Comment"
-end
-
---- Deduplicate checks by name, keeping the latest entry for each.
---- @param checks table[] statusCheckRollup array
---- @return table[] deduplicated checks preserving first-appearance order
-function M.deduplicate_checks(checks)
-	local seen = {}
-	local order = {}
-	for _, check in ipairs(checks) do
-		local key = check.name or check.context or "unknown"
-		if not seen[key] then
-			table.insert(order, key)
-		end
-		seen[key] = check
-	end
-	local result = {}
-	for _, key in ipairs(order) do
-		table.insert(result, seen[key])
-	end
-	return result
-end
-
---- Get sort priority for a check (lower = shown first).
---- @param check table check run or StatusContext object from statusCheckRollup
---- @return number priority, string name
-local function check_sort_key(check)
-	local status, conclusion = M.normalize_check(check)
-	local name = check.name or check.context or "unknown"
-
-	local priority
-	if conclusion == "FAILURE" or conclusion == "TIMED_OUT" or conclusion == "STARTUP_FAILURE" then
-		priority = 1
-	elseif conclusion == "CANCELLED" or conclusion == "ACTION_REQUIRED" then
-		priority = 2
-	elseif conclusion == "SKIPPED" or conclusion == "NEUTRAL" then
-		priority = 3
-	elseif status == "IN_PROGRESS" or status == "QUEUED" or status == "PENDING" then
-		priority = 4
-	elseif conclusion == "SUCCESS" then
-		priority = 5
-	else
-		priority = 6
-	end
-
-	return priority, name
-end
-
---- Sort checks by priority: failures first, then cancelled/action-required, then skipped/neutral,
---- then in-progress, then success, then any remaining states.
---- Within the same priority, checks are sorted alphabetically by name.
---- @param checks table[] statusCheckRollup array
---- @return table[] sorted copy of checks
-function M.sort_checks(checks)
-	local sorted = {}
-	for i, check in ipairs(checks) do
-		sorted[i] = check
-	end
-	table.sort(sorted, function(a, b)
-		local pa, na = check_sort_key(a)
-		local pb, nb = check_sort_key(b)
-		if pa ~= pb then
-			return pa < pb
-		end
-		return na < nb
-	end)
-	return sorted
-end
-
---- Build summary string for checks (e.g. "2/3 passed").
---- @param checks table[] statusCheckRollup array
---- @return string
-function M.build_checks_summary(checks)
-	if #checks == 0 then
-		return ""
-	end
-	local passed = 0
-	for _, check in ipairs(checks) do
-		local _, conclusion = M.normalize_check(check)
-		if conclusion == "SUCCESS" or conclusion == "NEUTRAL" or conclusion == "SKIPPED" then
-			passed = passed + 1
-		end
-	end
-	return string.format("%d/%d passed", passed, #checks)
-end
-
---- Map review state to display symbol and highlight group.
---- @param state string review state ("APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING")
---- @return string symbol, string hl_group
-function M.format_review_status(state)
-	if state == "APPROVED" then
-		return "✓", "DiagnosticOk"
-	elseif state == "CHANGES_REQUESTED" then
-		return "✗", "DiagnosticError"
-	elseif state == "COMMENTED" then
-		return "💬", "DiagnosticInfo"
-	elseif state == "DISMISSED" then
-		return "-", "Comment"
-	elseif state == "PENDING" then
-		return "●", "DiagnosticWarn"
-	end
-	return "?", "Comment"
-end
-
---- Build a unified list of reviewers from review requests and latest reviews.
---- Reviewers who appear in both lists use the latestReviews state.
---- @param review_requests table[] reviewRequests from gh pr view (each has login)
---- @param latest_reviews table[] latestReviews from gh pr view (each has author.login, state)
---- @return table[] list of { login: string, state: string } sorted by login
-function M.build_reviewers_list(review_requests, latest_reviews)
-	local reviewers = {}
-	local seen = {}
-
-	-- Add reviewers from latestReviews first (they have actual review state)
-	for _, review in ipairs(latest_reviews) do
-		local login = review.author and review.author.login
-		if login and not seen[login] then
-			seen[login] = true
-			table.insert(reviewers, { login = login, state = review.state or "COMMENTED" })
-		end
-	end
-
-	-- Add remaining reviewers from reviewRequests as PENDING
-	for _, req in ipairs(review_requests) do
-		local login = req.login
-		if login and not seen[login] then
-			seen[login] = true
-			table.insert(reviewers, { login = login, state = "PENDING" })
-		end
-	end
-
-	table.sort(reviewers, function(a, b)
-		return a.login < b.login
-	end)
-
-	return reviewers
-end
-
---- Build summary string for reviewers (e.g. "1/2 approved").
---- @param reviewers table[] list of { login: string, state: string }
---- @return string
-function M.build_reviewers_summary(reviewers)
-	if #reviewers == 0 then
-		return ""
-	end
-	local approved = 0
-	for _, reviewer in ipairs(reviewers) do
-		if reviewer.state == "APPROVED" then
-			approved = approved + 1
-		end
-	end
-	return string.format("%d/%d approved", approved, #reviewers)
-end
-
---- Calculate layout for split-pane overview windows.
---- @param columns number screen width
---- @param screen_lines number screen height
---- @param pct_w number total width percentage (0-100)
---- @param pct_h number total height percentage (0-100)
---- @param right_pct number right pane width as percentage of total (0-100)
---- @return table { left: { width, height, row, col }, right: { width, height, row, col } }
-function M.calculate_overview_layout(columns, screen_lines, pct_w, pct_h, right_pct)
-	local min_left = 20
-	local min_right = 15
-	local min_inner = min_left + min_right
-
-	right_pct = math.max(0, math.min(100, right_pct))
-	local total_width = math.max(math.floor(columns * pct_w / 100), min_inner + 4)
-	local height = math.floor(screen_lines * pct_h / 100)
-	local top_row = math.floor((screen_lines - height) / 2)
-	local start_col = math.floor((columns - total_width) / 2)
-	-- Each window has 2 border chars (left+right), 2 windows = 4 border chars total
-	local inner = total_width - 4
-	local right_width = math.min(math.max(math.floor(inner * right_pct / 100), min_right), inner - min_left)
-	local left_width = inner - right_width
-	return {
-		left = { width = left_width, height = height, row = top_row, col = start_col },
-		right = { width = right_width, height = height, row = top_row, col = start_col + left_width + 2 },
-	}
-end
-
---- Calculate upper window height for reply view.
---- @param line_count number total lines of formatted comments
---- @param min_height number minimum height
---- @param max_height number maximum height
---- @return number height
-function M.calculate_comments_height(line_count, min_height, max_height)
-	return math.max(min_height, math.min(line_count, max_height))
-end
-
---- Calculate dimensions for reply window (upper + lower).
---- @param screen_cols number screen width
---- @param screen_lines number screen height
---- @param comment_line_count number total lines of formatted comments
---- @param opts table|nil options
----   { min_upper_height?: number, max_upper_pct?: number, lower_height?: number,
----     max_width?: number, width_pct?: number }
---- @return table { width: number, upper_height: number, lower_height: number, row: number, col: number }
-function M.calculate_reply_window_dimensions(screen_cols, screen_lines, comment_line_count, opts)
-	opts = opts or {}
-	local width_pct = opts.width_pct or 0.6
-	local max_width = opts.max_width or 80
-	local min_upper = opts.min_upper_height or 3
-	local max_upper_pct = opts.max_upper_pct or 0.5
-	local lower_height = opts.lower_height or 5
-
-	local width = math.min(math.floor(screen_cols * width_pct), max_width)
-	local max_upper = math.floor(screen_lines * max_upper_pct)
-	local upper_height = M.calculate_comments_height(comment_line_count, min_upper, max_upper)
-
-	local total_height = upper_height + lower_height
-	local row = math.floor((screen_lines - total_height) / 2)
-	local col = math.floor((screen_cols - width) / 2)
-
-	return {
-		width = width,
-		upper_height = upper_height,
-		lower_height = lower_height,
-		row = row,
-		col = col,
-	}
-end
-
---- Format comments for reply window display with detailed highlight ranges.
---- @param comments table[] list of comment objects
---- @param format_date_fn fun(s: string): string
---- @return table { lines: string[], hl_ranges: table[] }
-function M.format_reply_comments_for_display(comments, format_date_fn)
-	local lines = {}
-	local hl_ranges = {}
-	for i, comment in ipairs(comments) do
-		local author = comment.user and comment.user.login or "unknown"
-		local created = format_date_fn(comment.created_at)
-		local header = string.format("@%s (%s):", author, created)
-		local header_line_idx = #lines
-		table.insert(lines, header)
-		-- Author highlight: from 0 to end of @username
-		local author_end = #author + 1 -- "@" + username
-		table.insert(hl_ranges, { line = header_line_idx, col_start = 0, col_end = author_end, hl = "ReviewCommentAuthor" })
-		-- Timestamp highlight: inside parentheses
-		local ts_start = author_end + 2 -- " ("
-		local ts_end = ts_start + #created
-		table.insert(
-			hl_ranges,
-			{ line = header_line_idx, col_start = ts_start, col_end = ts_end, hl = "ReviewCommentTimestamp" }
-		)
-
-		local comment_body = normalize_newlines(comment.body)
-		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
-			table.insert(lines, body_line)
-		end
-
-		if i < #comments then
-			table.insert(lines, "")
-			table.insert(lines, string.rep("-", 40))
-			table.insert(lines, "")
-		end
-	end
-	return { lines = lines, hl_ranges = hl_ranges }
-end
-
---- Build display lines for the left pane of PR overview (header, description, comments).
---- @param pr_info table PR data from gh pr view
---- @param issue_comments table[] issue-level comments
---- @param format_date_fn fun(s: string): string
---- @return table { lines: string[], hl_ranges: table[], sections: table, comment_positions: number[] }
-function M.build_overview_left_lines(pr_info, issue_comments, format_date_fn)
-	local lines = {}
-	local hl_ranges = {}
-	local sections = {}
-	local comment_positions = {}
-
-	-- PR header
-	local title = string.format("PR #%d: %s", pr_info.number or 0, pr_info.title or "")
-	table.insert(lines, title)
-	table.insert(hl_ranges, { line = #lines - 1, hl = "Title" })
-
-	local author = pr_info.author and pr_info.author.login or "unknown"
-	table.insert(lines, string.format("State: %s    Author: @%s", pr_info.state or "UNKNOWN", author))
-
-	table.insert(lines, string.format("Base: %s <- %s", pr_info.baseRefName or "", pr_info.headRefName or ""))
-	table.insert(lines, pr_info.url or "")
-
-	-- Description
-	table.insert(lines, "")
-	table.insert(lines, string.rep("-", 50))
-	local desc_header_line = #lines
-	table.insert(lines, "DESCRIPTION")
-	sections.description = #lines -- 1-indexed
-	table.insert(hl_ranges, { line = desc_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 50))
-
-	local body = normalize_newlines(pr_info.body)
-	if body == "" then
-		table.insert(lines, "(no description)")
-	else
-		for _, body_line in ipairs(vim.split(body, "\n")) do
-			table.insert(lines, body_line)
-		end
-	end
-
-	-- Comments
-	table.insert(lines, "")
-	table.insert(lines, string.rep("-", 50))
-	local comments_header_line = #lines
-	table.insert(lines, string.format("COMMENTS (%d)", #issue_comments))
-	sections.comments = #lines -- 1-indexed
-	table.insert(hl_ranges, { line = comments_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 50))
-
-	if #issue_comments == 0 then
-		table.insert(lines, "(no comments)")
-	else
-		for i, comment in ipairs(issue_comments) do
-			local comment_author = comment.user and comment.user.login or "unknown"
-			local created = format_date_fn(comment.created_at)
-			table.insert(lines, "")
-			local header = string.format("@%s  %s", comment_author, created)
-			table.insert(lines, header)
-			table.insert(comment_positions, #lines) -- 1-indexed header line
-			table.insert(hl_ranges, { line = #lines - 1, hl = "Special" })
-			local comment_body = normalize_newlines(comment.body)
-			for _, body_line in ipairs(vim.split(comment_body, "\n")) do
-				table.insert(lines, body_line)
-			end
-			if i < #issue_comments then
-				table.insert(lines, "")
-				table.insert(lines, string.rep("-", 30))
-			end
-		end
-	end
-
-	-- Footer
-	table.insert(lines, "")
-	table.insert(lines, " ]s/[s: sections  ]c/[c: comments  C: comment  R: refresh  <Tab>: switch  q: close")
-	table.insert(hl_ranges, { line = #lines - 1, hl = "Comment" })
-
-	return { lines = lines, hl_ranges = hl_ranges, sections = sections, comment_positions = comment_positions }
-end
-
---- Build display lines for the right pane of PR overview (reviewers, assignees, labels, CI status).
---- @param pr_info table PR data from gh pr view
---- @return table { lines: string[], hl_ranges: table[], check_urls: table }
-function M.build_overview_right_lines(pr_info)
-	local lines = {}
-	local hl_ranges = {}
-
-	-- Reviewers
-	local review_requests = pr_info.reviewRequests or {}
-	local latest_reviews = pr_info.latestReviews or {}
-	local reviewers = M.build_reviewers_list(review_requests, latest_reviews)
-
-	local reviewers_header_line = #lines
-	local reviewers_summary = M.build_reviewers_summary(reviewers)
-	if reviewers_summary ~= "" then
-		table.insert(lines, string.format("REVIEWERS (%s)", reviewers_summary))
-	else
-		table.insert(lines, "REVIEWERS")
-	end
-	table.insert(hl_ranges, { line = reviewers_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 25))
-
-	if #reviewers == 0 then
-		table.insert(lines, "(no reviewers)")
-	else
-		for _, reviewer in ipairs(reviewers) do
-			local symbol, hl = M.format_review_status(reviewer.state)
-			table.insert(lines, string.format("%s @%s  %s", symbol, reviewer.login, reviewer.state:lower()))
-			table.insert(hl_ranges, { line = #lines - 1, hl = hl })
-		end
-	end
-
-	-- Assignees
-	local assignees = pr_info.assignees or {}
-	table.insert(lines, "")
-	local assignees_header_line = #lines
-	table.insert(lines, "ASSIGNEES")
-	table.insert(hl_ranges, { line = assignees_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 25))
-
-	if #assignees == 0 then
-		table.insert(lines, "(no assignees)")
-	else
-		for _, assignee in ipairs(assignees) do
-			local login = assignee.login or assignee
-			table.insert(lines, "@" .. login)
-		end
-	end
-
-	-- Labels
-	local labels = pr_info.labels or {}
-	table.insert(lines, "")
-	local labels_header_line = #lines
-	table.insert(lines, "LABELS")
-	table.insert(hl_ranges, { line = labels_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 25))
-
-	if #labels == 0 then
-		table.insert(lines, "(no labels)")
-	else
-		for _, label in ipairs(labels) do
-			local name = label.name or label
-			table.insert(lines, name)
-		end
-	end
-
-	-- CI Status
-	local raw_checks = pr_info.statusCheckRollup or {}
-	local checks = M.sort_checks(M.deduplicate_checks(raw_checks))
-	local check_urls = {}
-	table.insert(lines, "")
-	table.insert(lines, string.rep("-", 25))
-	local ci_header_line = #lines
-	local summary = M.build_checks_summary(checks)
-	if summary ~= "" then
-		table.insert(lines, string.format("CI STATUS (%s)", summary))
-	else
-		table.insert(lines, "CI STATUS")
-	end
-	table.insert(hl_ranges, { line = ci_header_line, hl = "Title" })
-	table.insert(lines, string.rep("-", 25))
-
-	if #checks == 0 then
-		table.insert(lines, "(no checks)")
-	else
-		for _, check in ipairs(checks) do
-			local name = check.name or check.context or "unknown"
-			local symbol, hl = M.format_check_status(check)
-			local norm_status, norm_conclusion = M.normalize_check(check)
-			local conclusion = norm_conclusion ~= "" and norm_conclusion or norm_status
-			table.insert(lines, string.format("%s %s  %s", symbol, name, conclusion:lower()))
-			table.insert(hl_ranges, { line = #lines - 1, hl = hl })
-			local url = check.detailsUrl or check.targetUrl
-			if url then
-				check_urls[#lines - 1] = url
-			end
-		end
-	end
-
-	return { lines = lines, hl_ranges = hl_ranges, check_urls = check_urls }
-end
-
---- Refresh extmarks (virtual text) for the current buffer.
-function M.refresh_extmarks()
-	local state = config.state
-	if not state.active then
-		return
-	end
-
-	local buf = vim.api.nvim_get_current_buf()
-	local filepath = vim.api.nvim_buf_get_name(buf)
-	local diff = require("fude.diff")
-	local rel_path = diff.to_repo_relative(filepath)
-	if not rel_path then
-		return
-	end
-
-	vim.api.nvim_buf_clear_namespace(buf, state.ns_id, 0, -1)
-
-	local comments_mod = require("fude.comments")
-	local comment_lines = comments_mod.get_comment_lines(rel_path)
-
-	for _, line in ipairs(comment_lines) do
-		local comments = comments_mod.get_comments_at(rel_path, line)
-		local count = #comments
-
-		pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, line - 1, 0, {
-			virt_text = {
-				{ string.format(" %s%d", config.opts.signs.comment, count), config.opts.signs.comment_hl },
-			},
-			virt_text_pos = "eol",
-			priority = 50,
-		})
-	end
-
-	-- Pending comment indicators (GitHub pending review)
-	for key, _ in pairs(state.pending_comments) do
-		local parsed = comments_mod.parse_draft_key(key)
-		if parsed and parsed.type == "comment" and parsed.path == rel_path then
-			pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, parsed.start_line - 1, 0, {
-				virt_text = {
-					{ " " .. config.opts.signs.pending, config.opts.signs.pending_hl },
-				},
-				virt_text_pos = "eol",
-				priority = 45,
-			})
-		end
-	end
-
-	-- Draft indicators (local drafts, lower priority than pending)
-	local comments_parse = comments_mod.parse_draft_key
-	local comments_find = comments_mod.find_comment_by_id
-	for key, _ in pairs(state.drafts) do
-		-- Skip if this key is already in pending_comments
-		if state.pending_comments[key] then
-			goto draft_continue
-		end
-
-		local parsed = comments_parse(key)
-		if not parsed then
-			goto draft_continue
-		end
-
-		local draft_path, draft_line
-		if parsed.type == "comment" then
-			draft_path = parsed.path
-			draft_line = parsed.start_line
-		elseif parsed.type == "reply" then
-			local found = comments_find(parsed.comment_id, state.comment_map or {})
-			if found then
-				draft_path = found.path
-				draft_line = found.line
-			end
-		end
-
-		if draft_path == rel_path and draft_line then
-			pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, draft_line - 1, 0, {
-				virt_text = {
-					{ " " .. config.opts.signs.draft, config.opts.signs.draft_hl },
-				},
-				virt_text_pos = "eol",
-				priority = 40,
-			})
-		end
-
-		::draft_continue::
-	end
-end
-
---- Clear all extmarks for a specific buffer.
---- @param buf number|nil buffer handle (defaults to current)
-function M.clear_extmarks(buf)
-	local state = config.state
-	if state.ns_id then
-		pcall(vim.api.nvim_buf_clear_namespace, buf or 0, state.ns_id, 0, -1)
-	end
-end
-
---- Clear extmarks across all buffers.
-function M.clear_all_extmarks()
-	local state = config.state
-	if not state.ns_id then
-		return
-	end
-	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_valid(buf) then
-			pcall(vim.api.nvim_buf_clear_namespace, buf, state.ns_id, 0, -1)
-		end
-	end
-end
-
 --- Select review event type using vim.ui.select.
 --- @param callback fun(event: string|nil) called with "COMMENT", "APPROVE", "REQUEST_CHANGES", or nil if cancelled
 function M.select_review_event(callback)
@@ -839,7 +146,7 @@ function M.open_comment_input(callback, opts)
 
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, initial_lines)
 
-	local dim = M.calculate_float_dimensions(
+	local dim = format.calculate_float_dimensions(
 		vim.o.columns,
 		vim.o.lines,
 		config.opts.float.width or 50,
@@ -904,7 +211,7 @@ end
 --- @param opts table|nil { source_buf?: number, source_start_line?: number, source_end_line?: number }
 function M.show_comments_float(comments, opts)
 	opts = opts or {}
-	local result = M.format_comments_for_display(comments, config.format_date)
+	local result = format.format_comments_for_display(comments, config.format_date)
 
 	local buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, result.lines)
@@ -913,7 +220,7 @@ function M.show_comments_float(comments, opts)
 	vim.bo[buf].bufhidden = "wipe"
 	vim.bo[buf].filetype = "markdown"
 
-	local dim = M.calculate_float_dimensions(
+	local dim = format.calculate_float_dimensions(
 		vim.o.columns,
 		vim.o.lines,
 		config.opts.float.width or 50,
@@ -988,8 +295,8 @@ end
 --- @param issue_comments table[] issue-level comments
 --- @param opts table { on_new_comment: fun(), on_refresh: fun() }
 function M.show_overview_float(pr_info, issue_comments, opts)
-	local left_result = M.build_overview_left_lines(pr_info, issue_comments, config.format_date)
-	local right_result = M.build_overview_right_lines(pr_info)
+	local left_result = format.build_overview_left_lines(pr_info, issue_comments, config.format_date)
+	local right_result = format.build_overview_right_lines(pr_info)
 
 	-- Create left buffer
 	local left_buf = vim.api.nvim_create_buf(false, true)
@@ -1010,7 +317,7 @@ function M.show_overview_float(pr_info, issue_comments, opts)
 	-- Calculate split-pane layout
 	local ov = config.opts.overview or {}
 	local layout =
-		M.calculate_overview_layout(vim.o.columns, vim.o.lines, ov.width or 80, ov.height or 80, ov.right_width or 30)
+		format.calculate_overview_layout(vim.o.columns, vim.o.lines, ov.width or 80, ov.height or 80, ov.right_width or 30)
 
 	-- Use the taller content, capped at max layout height
 	local content_height = math.min(math.max(#left_result.lines, #right_result.lines) + 2, layout.left.height)
@@ -1228,10 +535,10 @@ function M.open_reply_window(comments, opts)
 	M.setup_reply_highlights()
 
 	-- Format comments
-	local result = M.format_reply_comments_for_display(comments, config.format_date)
+	local result = format.format_reply_comments_for_display(comments, config.format_date)
 
 	-- Calculate dimensions
-	local dim = M.calculate_float_dimensions(
+	local dim = format.calculate_float_dimensions(
 		vim.o.columns,
 		vim.o.lines,
 		config.opts.float.width or 50,

--- a/lua/fude/ui/extmarks.lua
+++ b/lua/fude/ui/extmarks.lua
@@ -1,0 +1,187 @@
+local M = {}
+local config = require("fude.config")
+
+--- Get the namespace ID for flash/highlight extmarks.
+--- Uses config.state.ns_id so existing cleanup paths (clear_extmarks, clear_all_extmarks) cover these.
+--- @return number
+local function get_flash_ns()
+	return config.state.ns_id or vim.api.nvim_create_namespace("fude")
+end
+
+--- Flash highlight a line temporarily.
+--- @param line number 1-indexed line number
+function M.flash_line(line)
+	local buf = vim.api.nvim_get_current_buf()
+	local ns = get_flash_ns()
+	local flash_opts = config.opts.flash or {}
+	local duration = flash_opts.duration or 200
+	local hl_group = flash_opts.hl_group or "Visual"
+
+	local extmark_id = vim.api.nvim_buf_set_extmark(buf, ns, line - 1, 0, {
+		line_hl_group = hl_group,
+		priority = 100,
+	})
+
+	vim.defer_fn(function()
+		pcall(vim.api.nvim_buf_del_extmark, buf, ns, extmark_id)
+	end, duration)
+end
+
+-- Store current comment line highlight info
+local comment_line_highlight = {
+	buf = nil,
+	extmark_ids = {},
+}
+
+--- Highlight lines persistently (for comment viewing).
+--- @param buf number buffer handle
+--- @param start_line number 1-indexed start line number
+--- @param end_line number 1-indexed end line number
+function M.highlight_comment_lines(buf, start_line, end_line)
+	M.clear_comment_line_highlight()
+
+	-- Ensure line numbers are valid
+	start_line = tonumber(start_line)
+	end_line = tonumber(end_line)
+	if not start_line or not end_line then
+		return
+	end
+
+	local ns = get_flash_ns()
+	local flash_opts = config.opts.flash or {}
+	local hl_group = flash_opts.hl_group or "Visual"
+
+	comment_line_highlight.buf = buf
+	comment_line_highlight.extmark_ids = {}
+
+	for line_num = start_line, end_line do
+		local extmark_id = vim.api.nvim_buf_set_extmark(buf, ns, line_num - 1, 0, {
+			line_hl_group = hl_group,
+			priority = 100,
+		})
+		table.insert(comment_line_highlight.extmark_ids, extmark_id)
+	end
+end
+
+--- Clear the persistent comment line highlight.
+function M.clear_comment_line_highlight()
+	if comment_line_highlight.buf then
+		local ns = get_flash_ns()
+		for _, extmark_id in ipairs(comment_line_highlight.extmark_ids) do
+			pcall(vim.api.nvim_buf_del_extmark, comment_line_highlight.buf, ns, extmark_id)
+		end
+	end
+	comment_line_highlight.buf = nil
+	comment_line_highlight.extmark_ids = {}
+end
+
+--- Refresh extmarks (virtual text) for the current buffer.
+function M.refresh_extmarks()
+	local state = config.state
+	if not state.active then
+		return
+	end
+
+	local buf = vim.api.nvim_get_current_buf()
+	local filepath = vim.api.nvim_buf_get_name(buf)
+	local diff = require("fude.diff")
+	local rel_path = diff.to_repo_relative(filepath)
+	if not rel_path then
+		return
+	end
+
+	vim.api.nvim_buf_clear_namespace(buf, state.ns_id, 0, -1)
+
+	local comments_mod = require("fude.comments")
+	local comment_lines = comments_mod.get_comment_lines(rel_path)
+
+	for _, line in ipairs(comment_lines) do
+		local comments = comments_mod.get_comments_at(rel_path, line)
+		local count = #comments
+
+		pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, line - 1, 0, {
+			virt_text = {
+				{ string.format(" %s%d", config.opts.signs.comment, count), config.opts.signs.comment_hl },
+			},
+			virt_text_pos = "eol",
+			priority = 50,
+		})
+	end
+
+	-- Pending comment indicators (GitHub pending review)
+	for key, _ in pairs(state.pending_comments) do
+		local parsed = comments_mod.parse_draft_key(key)
+		if parsed and parsed.type == "comment" and parsed.path == rel_path then
+			pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, parsed.start_line - 1, 0, {
+				virt_text = {
+					{ " " .. config.opts.signs.pending, config.opts.signs.pending_hl },
+				},
+				virt_text_pos = "eol",
+				priority = 45,
+			})
+		end
+	end
+
+	-- Draft indicators (local drafts, lower priority than pending)
+	local comments_parse = comments_mod.parse_draft_key
+	local comments_find = comments_mod.find_comment_by_id
+	for key, _ in pairs(state.drafts) do
+		-- Skip if this key is already in pending_comments
+		if state.pending_comments[key] then
+			goto draft_continue
+		end
+
+		local parsed = comments_parse(key)
+		if not parsed then
+			goto draft_continue
+		end
+
+		local draft_path, draft_line
+		if parsed.type == "comment" then
+			draft_path = parsed.path
+			draft_line = parsed.start_line
+		elseif parsed.type == "reply" then
+			local found = comments_find(parsed.comment_id, state.comment_map or {})
+			if found then
+				draft_path = found.path
+				draft_line = found.line
+			end
+		end
+
+		if draft_path == rel_path and draft_line then
+			pcall(vim.api.nvim_buf_set_extmark, buf, state.ns_id, draft_line - 1, 0, {
+				virt_text = {
+					{ " " .. config.opts.signs.draft, config.opts.signs.draft_hl },
+				},
+				virt_text_pos = "eol",
+				priority = 40,
+			})
+		end
+
+		::draft_continue::
+	end
+end
+
+--- Clear all extmarks for a specific buffer.
+--- @param buf number|nil buffer handle (defaults to current)
+function M.clear_extmarks(buf)
+	local state = config.state
+	if state.ns_id then
+		pcall(vim.api.nvim_buf_clear_namespace, buf or 0, state.ns_id, 0, -1)
+	end
+end
+
+--- Clear extmarks across all buffers.
+function M.clear_all_extmarks()
+	local state = config.state
+	if not state.ns_id then
+		return
+	end
+	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf) then
+			pcall(vim.api.nvim_buf_clear_namespace, buf, state.ns_id, 0, -1)
+		end
+	end
+end
+
+return M

--- a/lua/fude/ui/format.lua
+++ b/lua/fude/ui/format.lua
@@ -1,0 +1,541 @@
+local M = {}
+
+--- Normalize newlines by converting CRLF and CR to LF.
+--- @param s string|nil input string
+--- @return string normalized string
+local function normalize_newlines(s)
+	return (s or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
+end
+
+--- Calculate centered float window dimensions from percentage-based sizes.
+--- @param columns number screen width
+--- @param screen_lines number screen height
+--- @param pct_w number width percentage (0-100)
+--- @param pct_h number height percentage (0-100)
+--- @return table { width: number, height: number, row: number, col: number }
+function M.calculate_float_dimensions(columns, screen_lines, pct_w, pct_h)
+	local width = math.floor(columns * pct_w / 100)
+	local height = math.floor(screen_lines * pct_h / 100)
+	local row = math.floor((screen_lines - height) / 2)
+	local col = math.floor((columns - width) / 2)
+	return { width = width, height = height, row = row, col = col }
+end
+
+--- Format comment objects into display lines and highlight ranges.
+--- @param comments table[] list of comment objects
+--- @param format_date_fn fun(s: string): string
+--- @return table { lines: string[], hl_ranges: table[] }
+function M.format_comments_for_display(comments, format_date_fn)
+	local lines = {}
+	local hl_ranges = {}
+	for i, comment in ipairs(comments) do
+		local author = comment.user and comment.user.login or "unknown"
+		local created = format_date_fn(comment.created_at)
+		local header = string.format("@%s  %s", author, created)
+		table.insert(lines, header)
+		table.insert(hl_ranges, { line = #lines - 1, hl = "Title" })
+		local comment_body = normalize_newlines(comment.body)
+		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
+			table.insert(lines, body_line)
+		end
+		if i < #comments then
+			table.insert(lines, "")
+			table.insert(lines, string.rep("-", 40))
+			table.insert(lines, "")
+		end
+	end
+	return { lines = lines, hl_ranges = hl_ranges }
+end
+
+--- Normalize check fields into a consistent (status, conclusion) pair.
+--- Handles both CheckRun (status/conclusion) and StatusContext (state) objects.
+--- @param check table check run or status context object
+--- @return string status, string conclusion
+function M.normalize_check(check)
+	-- CheckRun: has status/conclusion fields
+	if check.status or check.conclusion then
+		return check.status or "", check.conclusion or ""
+	end
+
+	-- StatusContext: has state field (uppercase: "SUCCESS", "FAILURE", "PENDING", "ERROR", "EXPECTED")
+	local state = (check.state or ""):upper()
+	if state == "SUCCESS" then
+		return "COMPLETED", "SUCCESS"
+	elseif state == "EXPECTED" then
+		return "PENDING", ""
+	elseif state == "FAILURE" then
+		return "COMPLETED", "FAILURE"
+	elseif state == "ERROR" then
+		return "COMPLETED", "FAILURE"
+	elseif state == "PENDING" then
+		return "PENDING", ""
+	end
+
+	return "", ""
+end
+
+--- Map check conclusion/status to display symbol and highlight group.
+--- @param check table check run or status context object from statusCheckRollup
+--- @return string symbol, string hl_group
+function M.format_check_status(check)
+	local status, conclusion = M.normalize_check(check)
+
+	-- Not yet completed
+	if status == "IN_PROGRESS" or status == "QUEUED" or status == "PENDING" then
+		return "●", "DiagnosticWarn"
+	end
+
+	-- Completed with conclusion
+	if conclusion == "SUCCESS" then
+		return "✓", "DiagnosticOk"
+	elseif conclusion == "FAILURE" or conclusion == "TIMED_OUT" or conclusion == "STARTUP_FAILURE" then
+		return "✗", "DiagnosticError"
+	elseif conclusion == "NEUTRAL" or conclusion == "SKIPPED" then
+		return "-", "Comment"
+	elseif conclusion == "CANCELLED" or conclusion == "ACTION_REQUIRED" then
+		return "!", "DiagnosticWarn"
+	end
+
+	return "?", "Comment"
+end
+
+--- Deduplicate checks by name, keeping the latest entry for each.
+--- @param checks table[] statusCheckRollup array
+--- @return table[] deduplicated checks preserving first-appearance order
+function M.deduplicate_checks(checks)
+	local seen = {}
+	local order = {}
+	for _, check in ipairs(checks) do
+		local key = check.name or check.context or "unknown"
+		if not seen[key] then
+			table.insert(order, key)
+		end
+		seen[key] = check
+	end
+	local result = {}
+	for _, key in ipairs(order) do
+		table.insert(result, seen[key])
+	end
+	return result
+end
+
+--- Get sort priority for a check (lower = shown first).
+--- @param check table check run or StatusContext object from statusCheckRollup
+--- @return number priority, string name
+local function check_sort_key(check)
+	local status, conclusion = M.normalize_check(check)
+	local name = check.name or check.context or "unknown"
+
+	local priority
+	if conclusion == "FAILURE" or conclusion == "TIMED_OUT" or conclusion == "STARTUP_FAILURE" then
+		priority = 1
+	elseif conclusion == "CANCELLED" or conclusion == "ACTION_REQUIRED" then
+		priority = 2
+	elseif conclusion == "SKIPPED" or conclusion == "NEUTRAL" then
+		priority = 3
+	elseif status == "IN_PROGRESS" or status == "QUEUED" or status == "PENDING" then
+		priority = 4
+	elseif conclusion == "SUCCESS" then
+		priority = 5
+	else
+		priority = 6
+	end
+
+	return priority, name
+end
+
+--- Sort checks by priority: failures first, then cancelled/action-required, then skipped/neutral,
+--- then in-progress, then success, then any remaining states.
+--- Within the same priority, checks are sorted alphabetically by name.
+--- @param checks table[] statusCheckRollup array
+--- @return table[] sorted copy of checks
+function M.sort_checks(checks)
+	local sorted = {}
+	for i, check in ipairs(checks) do
+		sorted[i] = check
+	end
+	table.sort(sorted, function(a, b)
+		local pa, na = check_sort_key(a)
+		local pb, nb = check_sort_key(b)
+		if pa ~= pb then
+			return pa < pb
+		end
+		return na < nb
+	end)
+	return sorted
+end
+
+--- Build summary string for checks (e.g. "2/3 passed").
+--- @param checks table[] statusCheckRollup array
+--- @return string
+function M.build_checks_summary(checks)
+	if #checks == 0 then
+		return ""
+	end
+	local passed = 0
+	for _, check in ipairs(checks) do
+		local _, conclusion = M.normalize_check(check)
+		if conclusion == "SUCCESS" or conclusion == "NEUTRAL" or conclusion == "SKIPPED" then
+			passed = passed + 1
+		end
+	end
+	return string.format("%d/%d passed", passed, #checks)
+end
+
+--- Map review state to display symbol and highlight group.
+--- @param state string review state ("APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING")
+--- @return string symbol, string hl_group
+function M.format_review_status(state)
+	if state == "APPROVED" then
+		return "✓", "DiagnosticOk"
+	elseif state == "CHANGES_REQUESTED" then
+		return "✗", "DiagnosticError"
+	elseif state == "COMMENTED" then
+		return "💬", "DiagnosticInfo"
+	elseif state == "DISMISSED" then
+		return "-", "Comment"
+	elseif state == "PENDING" then
+		return "●", "DiagnosticWarn"
+	end
+	return "?", "Comment"
+end
+
+--- Build a unified list of reviewers from review requests and latest reviews.
+--- Reviewers who appear in both lists use the latestReviews state.
+--- @param review_requests table[] reviewRequests from gh pr view (each has login)
+--- @param latest_reviews table[] latestReviews from gh pr view (each has author.login, state)
+--- @return table[] list of { login: string, state: string } sorted by login
+function M.build_reviewers_list(review_requests, latest_reviews)
+	local reviewers = {}
+	local seen = {}
+
+	-- Add reviewers from latestReviews first (they have actual review state)
+	for _, review in ipairs(latest_reviews) do
+		local login = review.author and review.author.login
+		if login and not seen[login] then
+			seen[login] = true
+			table.insert(reviewers, { login = login, state = review.state or "COMMENTED" })
+		end
+	end
+
+	-- Add remaining reviewers from reviewRequests as PENDING
+	for _, req in ipairs(review_requests) do
+		local login = req.login
+		if login and not seen[login] then
+			seen[login] = true
+			table.insert(reviewers, { login = login, state = "PENDING" })
+		end
+	end
+
+	table.sort(reviewers, function(a, b)
+		return a.login < b.login
+	end)
+
+	return reviewers
+end
+
+--- Build summary string for reviewers (e.g. "1/2 approved").
+--- @param reviewers table[] list of { login: string, state: string }
+--- @return string
+function M.build_reviewers_summary(reviewers)
+	if #reviewers == 0 then
+		return ""
+	end
+	local approved = 0
+	for _, reviewer in ipairs(reviewers) do
+		if reviewer.state == "APPROVED" then
+			approved = approved + 1
+		end
+	end
+	return string.format("%d/%d approved", approved, #reviewers)
+end
+
+--- Calculate layout for split-pane overview windows.
+--- @param columns number screen width
+--- @param screen_lines number screen height
+--- @param pct_w number total width percentage (0-100)
+--- @param pct_h number total height percentage (0-100)
+--- @param right_pct number right pane width as percentage of total (0-100)
+--- @return table { left: { width, height, row, col }, right: { width, height, row, col } }
+function M.calculate_overview_layout(columns, screen_lines, pct_w, pct_h, right_pct)
+	local min_left = 20
+	local min_right = 15
+	local min_inner = min_left + min_right
+
+	right_pct = math.max(0, math.min(100, right_pct))
+	local total_width = math.max(math.floor(columns * pct_w / 100), min_inner + 4)
+	local height = math.floor(screen_lines * pct_h / 100)
+	local top_row = math.floor((screen_lines - height) / 2)
+	local start_col = math.floor((columns - total_width) / 2)
+	-- Each window has 2 border chars (left+right), 2 windows = 4 border chars total
+	local inner = total_width - 4
+	local right_width = math.min(math.max(math.floor(inner * right_pct / 100), min_right), inner - min_left)
+	local left_width = inner - right_width
+	return {
+		left = { width = left_width, height = height, row = top_row, col = start_col },
+		right = { width = right_width, height = height, row = top_row, col = start_col + left_width + 2 },
+	}
+end
+
+--- Calculate upper window height for reply view.
+--- @param line_count number total lines of formatted comments
+--- @param min_height number minimum height
+--- @param max_height number maximum height
+--- @return number height
+function M.calculate_comments_height(line_count, min_height, max_height)
+	return math.max(min_height, math.min(line_count, max_height))
+end
+
+--- Calculate dimensions for reply window (upper + lower).
+--- @param screen_cols number screen width
+--- @param screen_lines number screen height
+--- @param comment_line_count number total lines of formatted comments
+--- @param opts table|nil options
+---   { min_upper_height?: number, max_upper_pct?: number, lower_height?: number,
+---     max_width?: number, width_pct?: number }
+--- @return table { width: number, upper_height: number, lower_height: number, row: number, col: number }
+function M.calculate_reply_window_dimensions(screen_cols, screen_lines, comment_line_count, opts)
+	opts = opts or {}
+	local width_pct = opts.width_pct or 0.6
+	local max_width = opts.max_width or 80
+	local min_upper = opts.min_upper_height or 3
+	local max_upper_pct = opts.max_upper_pct or 0.5
+	local lower_height = opts.lower_height or 5
+
+	local width = math.min(math.floor(screen_cols * width_pct), max_width)
+	local max_upper = math.floor(screen_lines * max_upper_pct)
+	local upper_height = M.calculate_comments_height(comment_line_count, min_upper, max_upper)
+
+	local total_height = upper_height + lower_height
+	local row = math.floor((screen_lines - total_height) / 2)
+	local col = math.floor((screen_cols - width) / 2)
+
+	return {
+		width = width,
+		upper_height = upper_height,
+		lower_height = lower_height,
+		row = row,
+		col = col,
+	}
+end
+
+--- Format comments for reply window display with detailed highlight ranges.
+--- @param comments table[] list of comment objects
+--- @param format_date_fn fun(s: string): string
+--- @return table { lines: string[], hl_ranges: table[] }
+function M.format_reply_comments_for_display(comments, format_date_fn)
+	local lines = {}
+	local hl_ranges = {}
+	for i, comment in ipairs(comments) do
+		local author = comment.user and comment.user.login or "unknown"
+		local created = format_date_fn(comment.created_at)
+		local header = string.format("@%s (%s):", author, created)
+		local header_line_idx = #lines
+		table.insert(lines, header)
+		-- Author highlight: from 0 to end of @username
+		local author_end = #author + 1 -- "@" + username
+		table.insert(hl_ranges, { line = header_line_idx, col_start = 0, col_end = author_end, hl = "ReviewCommentAuthor" })
+		-- Timestamp highlight: inside parentheses
+		local ts_start = author_end + 2 -- " ("
+		local ts_end = ts_start + #created
+		table.insert(
+			hl_ranges,
+			{ line = header_line_idx, col_start = ts_start, col_end = ts_end, hl = "ReviewCommentTimestamp" }
+		)
+
+		local comment_body = normalize_newlines(comment.body)
+		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
+			table.insert(lines, body_line)
+		end
+
+		if i < #comments then
+			table.insert(lines, "")
+			table.insert(lines, string.rep("-", 40))
+			table.insert(lines, "")
+		end
+	end
+	return { lines = lines, hl_ranges = hl_ranges }
+end
+
+--- Build display lines for the left pane of PR overview (header, description, comments).
+--- @param pr_info table PR data from gh pr view
+--- @param issue_comments table[] issue-level comments
+--- @param format_date_fn fun(s: string): string
+--- @return table { lines: string[], hl_ranges: table[], sections: table, comment_positions: number[] }
+function M.build_overview_left_lines(pr_info, issue_comments, format_date_fn)
+	local lines = {}
+	local hl_ranges = {}
+	local sections = {}
+	local comment_positions = {}
+
+	-- PR header
+	local title = string.format("PR #%d: %s", pr_info.number or 0, pr_info.title or "")
+	table.insert(lines, title)
+	table.insert(hl_ranges, { line = #lines - 1, hl = "Title" })
+
+	local author = pr_info.author and pr_info.author.login or "unknown"
+	table.insert(lines, string.format("State: %s    Author: @%s", pr_info.state or "UNKNOWN", author))
+
+	table.insert(lines, string.format("Base: %s <- %s", pr_info.baseRefName or "", pr_info.headRefName or ""))
+	table.insert(lines, pr_info.url or "")
+
+	-- Description
+	table.insert(lines, "")
+	table.insert(lines, string.rep("-", 50))
+	local desc_header_line = #lines
+	table.insert(lines, "DESCRIPTION")
+	sections.description = #lines -- 1-indexed
+	table.insert(hl_ranges, { line = desc_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 50))
+
+	local body = normalize_newlines(pr_info.body)
+	if body == "" then
+		table.insert(lines, "(no description)")
+	else
+		for _, body_line in ipairs(vim.split(body, "\n")) do
+			table.insert(lines, body_line)
+		end
+	end
+
+	-- Comments
+	table.insert(lines, "")
+	table.insert(lines, string.rep("-", 50))
+	local comments_header_line = #lines
+	table.insert(lines, string.format("COMMENTS (%d)", #issue_comments))
+	sections.comments = #lines -- 1-indexed
+	table.insert(hl_ranges, { line = comments_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 50))
+
+	if #issue_comments == 0 then
+		table.insert(lines, "(no comments)")
+	else
+		for i, comment in ipairs(issue_comments) do
+			local comment_author = comment.user and comment.user.login or "unknown"
+			local created = format_date_fn(comment.created_at)
+			table.insert(lines, "")
+			local header = string.format("@%s  %s", comment_author, created)
+			table.insert(lines, header)
+			table.insert(comment_positions, #lines) -- 1-indexed header line
+			table.insert(hl_ranges, { line = #lines - 1, hl = "Special" })
+			local comment_body = normalize_newlines(comment.body)
+			for _, body_line in ipairs(vim.split(comment_body, "\n")) do
+				table.insert(lines, body_line)
+			end
+			if i < #issue_comments then
+				table.insert(lines, "")
+				table.insert(lines, string.rep("-", 30))
+			end
+		end
+	end
+
+	-- Footer
+	table.insert(lines, "")
+	table.insert(lines, " ]s/[s: sections  ]c/[c: comments  C: comment  R: refresh  <Tab>: switch  q: close")
+	table.insert(hl_ranges, { line = #lines - 1, hl = "Comment" })
+
+	return { lines = lines, hl_ranges = hl_ranges, sections = sections, comment_positions = comment_positions }
+end
+
+--- Build display lines for the right pane of PR overview (reviewers, assignees, labels, CI status).
+--- @param pr_info table PR data from gh pr view
+--- @return table { lines: string[], hl_ranges: table[], check_urls: table }
+function M.build_overview_right_lines(pr_info)
+	local lines = {}
+	local hl_ranges = {}
+
+	-- Reviewers
+	local review_requests = pr_info.reviewRequests or {}
+	local latest_reviews = pr_info.latestReviews or {}
+	local reviewers = M.build_reviewers_list(review_requests, latest_reviews)
+
+	local reviewers_header_line = #lines
+	local reviewers_summary = M.build_reviewers_summary(reviewers)
+	if reviewers_summary ~= "" then
+		table.insert(lines, string.format("REVIEWERS (%s)", reviewers_summary))
+	else
+		table.insert(lines, "REVIEWERS")
+	end
+	table.insert(hl_ranges, { line = reviewers_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 25))
+
+	if #reviewers == 0 then
+		table.insert(lines, "(no reviewers)")
+	else
+		for _, reviewer in ipairs(reviewers) do
+			local symbol, hl = M.format_review_status(reviewer.state)
+			table.insert(lines, string.format("%s @%s  %s", symbol, reviewer.login, reviewer.state:lower()))
+			table.insert(hl_ranges, { line = #lines - 1, hl = hl })
+		end
+	end
+
+	-- Assignees
+	local assignees = pr_info.assignees or {}
+	table.insert(lines, "")
+	local assignees_header_line = #lines
+	table.insert(lines, "ASSIGNEES")
+	table.insert(hl_ranges, { line = assignees_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 25))
+
+	if #assignees == 0 then
+		table.insert(lines, "(no assignees)")
+	else
+		for _, assignee in ipairs(assignees) do
+			local login = assignee.login or assignee
+			table.insert(lines, "@" .. login)
+		end
+	end
+
+	-- Labels
+	local labels = pr_info.labels or {}
+	table.insert(lines, "")
+	local labels_header_line = #lines
+	table.insert(lines, "LABELS")
+	table.insert(hl_ranges, { line = labels_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 25))
+
+	if #labels == 0 then
+		table.insert(lines, "(no labels)")
+	else
+		for _, label in ipairs(labels) do
+			local name = label.name or label
+			table.insert(lines, name)
+		end
+	end
+
+	-- CI Status
+	local raw_checks = pr_info.statusCheckRollup or {}
+	local checks = M.sort_checks(M.deduplicate_checks(raw_checks))
+	local check_urls = {}
+	table.insert(lines, "")
+	table.insert(lines, string.rep("-", 25))
+	local ci_header_line = #lines
+	local summary = M.build_checks_summary(checks)
+	if summary ~= "" then
+		table.insert(lines, string.format("CI STATUS (%s)", summary))
+	else
+		table.insert(lines, "CI STATUS")
+	end
+	table.insert(hl_ranges, { line = ci_header_line, hl = "Title" })
+	table.insert(lines, string.rep("-", 25))
+
+	if #checks == 0 then
+		table.insert(lines, "(no checks)")
+	else
+		for _, check in ipairs(checks) do
+			local name = check.name or check.context or "unknown"
+			local symbol, hl = M.format_check_status(check)
+			local norm_status, norm_conclusion = M.normalize_check(check)
+			local conclusion = norm_conclusion ~= "" and norm_conclusion or norm_status
+			table.insert(lines, string.format("%s %s  %s", symbol, name, conclusion:lower()))
+			table.insert(hl_ranges, { line = #lines - 1, hl = hl })
+			local url = check.detailsUrl or check.targetUrl
+			if url then
+				check_urls[#lines - 1] = url
+			end
+		end
+	end
+
+	return { lines = lines, hl_ranges = hl_ranges, check_urls = check_urls }
+end
+
+return M


### PR DESCRIPTION
## Summary

- **ui.lua** (1,401 → ~700 lines): 純粋フォーマット関数を `ui/format.lua` (18関数)、extmark管理を `ui/extmarks.lua` (6関数) に抽出
- **comments.lua** (1,200 → ~680 lines): 純粋データ関数を `comments/data.lua` (14関数)、GitHub API同期を `comments/sync.lua` (5関数) に抽出
- 外部インターフェース変更なし — 元モジュールがファサードとして全関数をre-export
- CLAUDE.md アーキテクチャセクションを新構造に合わせて更新

```
lua/fude/
├── ui.lua                    (facade + float windows, ~700 lines)
├── ui/
│   ├── format.lua            (pure format functions, ~480 lines)
│   └── extmarks.lua          (extmark management, ~180 lines)
├── comments.lua              (facade + actions/navigation, ~680 lines)
├── comments/
│   ├── data.lua              (pure data functions, ~280 lines)
│   └── sync.lua              (GitHub API sync, ~270 lines)
```

## Test plan

- [x] `make all` — lint 0 warnings, format-check passed, 306/306 tests passed
- [x] テストファイル変更なし（ファサードが全関数をre-export）
- [x] 循環依存なし（`sync.lua` → `ui` は遅延 `require`、`extmarks.lua` → `comments` も遅延 `require`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)