### PR TITLE
feat: FudeEditPR コマンドの追加

### DIFF
--- a/.claude/review-lessons.md
+++ b/.claude/review-lessons.md
@@ -4,3 +4,8 @@
 - **問題**: `format_path` のようにユーザーが config で関数を指定できる場合、戻り値が nil/非string/エラーになりうるが、呼び出し側で防御していなかった
 - **対策**: ユーザー定義関数の呼び出しは pcall で保護し、戻り値の type チェック + 元の値へのフォールバックを入れる。集約ヘルパー（config.format_path）で防御すれば下流の pure function は最小限の type チェックで済む
 - **該当箇所**: `lua/fude/config.lua` (format_path), `lua/fude/ui/format.lua`, `lua/fude/comments/data.lua`, `lua/fude/scope.lua`
+
+## 堅牢性: gh CLI ラッパー関数の detached HEAD 対策漏れ (PR #100, 2026-03-29)
+- **問題**: `gh pr view` / `gh pr edit` はブランチなし（detached HEAD）でハングする。`get_pr_info` では対策済みだったが、新規追加の `get_pr_title_body` に同パターンを適用し忘れた
+- **対策**: `gh pr view` / `gh pr edit` を引数なし（カレントブランチ推論）で呼ぶ新関数を追加する際は、`get_pr_info` の detached HEAD 検出パターン（`git symbolic-ref` チェック → commit SHA → PR 番号解決）を適用する。呼び出し元で PR 番号を事前解決して渡す方式も有効
+- **該当箇所**: `lua/fude/gh.lua`, `lua/fude/pr.lua`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 - **`files.lua`** — Changed files display via Telescope picker (with diff preview and viewed state toggle via `<Tab>`) or quickfix list fallback. Shows GitHub viewed status for each file.
 - **`scope.lua`** — Review scope selection and navigation. Provides a Telescope picker (or `vim.ui.select` fallback) for choosing between full PR scope and individual commit scope, with commit index display (`[1/10]`) and current scope marker (`▶`). Supports next/prev scope navigation (`next_scope`/`prev_scope`), marking commits as reviewed via `<Tab>` in the Telescope picker (tracked locally in `state.reviewed_commits`), and statusline integration (`statusline()`). On commit scope: checks out the commit, fetches commit-specific changed files, updates gitsigns base to `sha^` (global), and refreshes the diff preview. On full PR scope: restores the original HEAD, re-fetches PR-wide changed files, and computes merge-base (per-buffer gitsigns base is applied via `GitSignsUpdate` autocmd in init.lua).
 - **`overview.lua`** — PR overview display: fetches extended PR info and issue-level comments, renders in a centered float with keymaps for commenting and refreshing.
-- **`pr.lua`** — Draft PR creation from templates. Searches for `PULL_REQUEST_TEMPLATE` files in standard GitHub locations, shows Telescope picker when multiple templates exist, and opens a two-pane float (title + body) for composing the PR. Submits via `gh pr create --draft`. Independent of review mode (`state.active`).
+- **`pr.lua`** — PR creation and editing. `M.create()` creates draft PRs from templates: searches for `PULL_REQUEST_TEMPLATE` files in standard GitHub locations, shows Telescope picker when multiple templates exist, and opens a two-pane float (title + body) for composing the PR. Submits via `gh pr create --draft`. `M.edit()` edits existing PR title/body: uses `state.pr_number` when review mode is active, otherwise detects via `gh pr view`. Both functions are independent of review mode (`state.active`).
 
 ### Key Patterns
 
@@ -59,7 +59,7 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 | Field | W (Write) | R (Read) |
 |-------|-----------|----------|
 | `active` | init | comments, comments/sync, ui/extmarks, files, scope, preview, overview, ui/sidepanel |
-| `pr_number` | init | comments, comments/sync, ui, files, scope, overview |
+| `pr_number` | init | comments, comments/sync, ui, files, scope, overview, pr |
 | `base_ref` | init | init, preview, scope |
 | `head_ref` | init | scope |
 | `merge_base_sha` | init, scope | init, scope |

--- a/doc/fude.txt
+++ b/doc/fude.txt
@@ -256,6 +256,21 @@ Using lazy.nvim: >lua
     Does not require an active review session. Works in any git
     repository with a branch that can create a PR.
 
+:FudeEditPR                                              *:FudeEditPR*
+    Edit the current PR's title and body. Opens a two-pane floating
+    window similar to |:FudeCreatePR|:
+    - Upper pane: PR title (editable)
+    - Lower pane: PR body (editable, Markdown)
+
+    Press `<Tab>` to switch between panes.
+    Press `<CR>` to update the PR.
+    Press `q` to cancel.
+
+    When review mode is active, uses the PR from the current session.
+    Otherwise, detects the PR from the current branch using `gh pr view`.
+
+    Does not require an active review session.
+
 :FudeReviewSubmit                                    *:FudeReviewSubmit*
     Submit all pending comments as a single GitHub review. This allows
     you to batch comments together instead of posting them individually.

--- a/lua/fude/gh.lua
+++ b/lua/fude/gh.lua
@@ -632,19 +632,44 @@ function M.update_comment(comment_id, body, callback)
 end
 
 --- Get PR title and body for editing.
+--- When pr_number is nil, detects detached HEAD and resolves PR number first
+--- to avoid `gh pr view` hanging without a branch.
 --- @param pr_number number|nil PR number (nil to use current branch's PR)
 --- @param callback fun(err: string|nil, data: table|nil)
 function M.get_pr_title_body(pr_number, callback)
-	local args = { "pr", "view", "--json", "title,body" }
-	if pr_number then
-		table.insert(args, 3, tostring(pr_number))
-	end
-	M.run_json(args, function(err, data)
-		if err then
-			return callback(err, nil)
+	local function fetch(num)
+		local args = { "pr", "view", "--json", "title,body" }
+		if num then
+			table.insert(args, 3, tostring(num))
 		end
-		callback(nil, { title = data.title or "", body = data.body or "" })
-	end)
+		M.run_json(args, function(err, data)
+			if err then
+				return callback(err, nil)
+			end
+			callback(nil, { title = data.title or "", body = data.body or "" })
+		end)
+	end
+
+	if pr_number then
+		return fetch(pr_number)
+	end
+
+	-- Detect detached HEAD: resolve PR number via commit SHA first
+	local ref_result = vim.system({ "git", "symbolic-ref", "--quiet", "HEAD" }, { text = true }):wait()
+	if ref_result.code ~= 0 then
+		local sha, sha_err = M.get_head_sha()
+		if not sha then
+			return callback(sha_err or "Not in a git repository", nil)
+		end
+		return M.get_pr_by_commit(sha, function(err, pr_data)
+			if err then
+				return callback(err, nil)
+			end
+			fetch(pr_data.number)
+		end)
+	end
+
+	fetch(nil)
 end
 
 --- Edit PR title and body.

--- a/lua/fude/gh.lua
+++ b/lua/fude/gh.lua
@@ -631,6 +631,37 @@ function M.update_comment(comment_id, body, callback)
 	}, callback)
 end
 
+--- Get PR title and body for editing.
+--- @param pr_number number|nil PR number (nil to use current branch's PR)
+--- @param callback fun(err: string|nil, data: table|nil)
+function M.get_pr_title_body(pr_number, callback)
+	local args = { "pr", "view", "--json", "title,body" }
+	if pr_number then
+		table.insert(args, 3, tostring(pr_number))
+	end
+	M.run_json(args, function(err, data)
+		if err then
+			return callback(err, nil)
+		end
+		callback(nil, { title = data.title or "", body = data.body or "" })
+	end)
+end
+
+--- Edit PR title and body.
+--- @param pr_number number|nil PR number (nil to use current branch's PR)
+--- @param title string
+--- @param body string
+--- @param callback fun(err: string|nil)
+function M.edit_pr(pr_number, title, body, callback)
+	local args = { "pr", "edit", "--title", title, "--body", body }
+	if pr_number then
+		table.insert(args, 3, tostring(pr_number))
+	end
+	M.run(args, function(err, _)
+		callback(err)
+	end)
+end
+
 --- Delete a review comment.
 --- @param comment_id number
 --- @param callback fun(err: string|nil)

--- a/lua/fude/pr.lua
+++ b/lua/fude/pr.lua
@@ -118,13 +118,16 @@ function M.find_templates()
 	return templates
 end
 
---- Open the PR creation float with explicit title and body content.
+--- Open the PR float with explicit title and body content.
 --- @param title_lines string[]|nil initial title lines (default: {""})
 --- @param body_lines string[]|nil initial body lines (default: {""})
---- @param from_draft boolean|nil true when restoring from a saved draft
-function M.open_pr_float(title_lines, body_lines, from_draft)
+--- @param opts table|nil options: { mode: "create"|"edit", footer: string, on_submit: fun(title, body) }
+function M.open_pr_float(title_lines, body_lines, opts)
 	title_lines = title_lines or { "" }
 	body_lines = body_lines or { "" }
+	opts = opts or {}
+	local mode = opts.mode or "create"
+	local is_edit = mode == "edit"
 
 	-- Create title buffer (editable, single line)
 	local title_buf = vim.api.nvim_create_buf(false, true)
@@ -155,6 +158,18 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 	local upper_border = { "╭", "─", "╮", "│", "", "", "", "│" }
 	local lower_border = { "├", "─", "┤", "│", "╯", "─", "╰", "│" }
 
+	-- Determine footer text
+	local footer_text = opts.footer
+	if not footer_text then
+		if is_edit then
+			footer_text = " <CR> update | q cancel "
+		elseif opts.from_draft then
+			footer_text = " <CR> create draft | q cancel (draft restored) "
+		else
+			footer_text = " <CR> create draft | q cancel "
+		end
+	end
+
 	-- Open title window (focused)
 	local title_win = vim.api.nvim_open_win(title_buf, true, {
 		relative = "editor",
@@ -179,7 +194,7 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 		border = lower_border,
 		title = " PR Body ",
 		title_pos = "center",
-		footer = from_draft and " <CR> create draft | q cancel (draft restored) " or " <CR> create draft | q cancel ",
+		footer = footer_text,
 		footer_pos = "center",
 	})
 	vim.wo[body_win].wrap = true
@@ -206,10 +221,18 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 			return
 		end
 
+		close_all()
+
+		-- Use custom submit handler if provided
+		if opts.on_submit then
+			opts.on_submit(parsed.title, parsed.body)
+			return
+		end
+
+		-- Default: create draft PR
 		-- Save draft before attempting to create PR
 		M.save_draft(t_lines, b_lines)
 
-		close_all()
 		vim.notify("fude.nvim: Creating draft PR...", vim.log.levels.INFO)
 
 		gh.create_draft_pr(parsed.title, parsed.body, function(err, data)
@@ -241,8 +264,10 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 		end
 	end
 
+	local submit_desc = is_edit and "Update PR" or "Create draft PR"
+
 	-- Title buffer keymaps
-	vim.keymap.set("n", "<CR>", submit, { buffer = title_buf, desc = "Create draft PR" })
+	vim.keymap.set("n", "<CR>", submit, { buffer = title_buf, desc = submit_desc })
 	vim.keymap.set("n", "q", cancel, { buffer = title_buf, desc = "Cancel" })
 	vim.keymap.set("n", "<Tab>", function()
 		if vim.api.nvim_win_is_valid(body_win) then
@@ -263,7 +288,7 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 	)
 
 	-- Body buffer keymaps
-	vim.keymap.set("n", "<CR>", submit, { buffer = body_buf, desc = "Create draft PR" })
+	vim.keymap.set("n", "<CR>", submit, { buffer = body_buf, desc = submit_desc })
 	vim.keymap.set("n", "q", cancel, { buffer = body_buf, desc = "Cancel" })
 	vim.keymap.set("n", "<Tab>", function()
 		if vim.api.nvim_win_is_valid(title_win) then
@@ -272,7 +297,7 @@ function M.open_pr_float(title_lines, body_lines, from_draft)
 	end, { buffer = body_buf, desc = "Go to title" })
 
 	-- Autocmd: close both when one closes
-	local augroup = vim.api.nvim_create_augroup("fude_pr_create_" .. title_win, { clear = true })
+	local augroup = vim.api.nvim_create_augroup("fude_pr_float_" .. title_win, { clear = true })
 	vim.api.nvim_create_autocmd("WinClosed", {
 		group = augroup,
 		pattern = { tostring(title_win), tostring(body_win) },
@@ -294,7 +319,7 @@ end
 local function open_from_draft()
 	local d = M.get_draft()
 	if d then
-		M.open_pr_float(d.title_lines, d.body_lines, true)
+		M.open_pr_float(d.title_lines, d.body_lines, { from_draft = true })
 	end
 end
 
@@ -447,6 +472,41 @@ function M.select_template(entries, callback)
 			end,
 		})
 		:find()
+end
+
+--- Edit the current PR's title and body.
+--- Uses state.pr_number when review mode is active, otherwise detects via gh pr view.
+function M.edit()
+	local pr_number = config.state.active and config.state.pr_number or nil
+
+	vim.notify("fude.nvim: Loading PR...", vim.log.levels.INFO)
+
+	gh.get_pr_title_body(pr_number, function(err, data)
+		vim.schedule(function()
+			if err then
+				vim.notify("fude.nvim: " .. err, vim.log.levels.ERROR)
+				return
+			end
+
+			local body_lines = vim.split(data.body or "", "\n", { plain = true })
+			M.open_pr_float({ data.title }, body_lines, {
+				mode = "edit",
+				footer = " <CR> update | q cancel ",
+				on_submit = function(title, body)
+					vim.notify("fude.nvim: Updating PR...", vim.log.levels.INFO)
+					gh.edit_pr(pr_number, title, body, function(edit_err)
+						vim.schedule(function()
+							if edit_err then
+								vim.notify("fude.nvim: " .. edit_err, vim.log.levels.ERROR)
+							else
+								vim.notify("fude.nvim: PR updated", vim.log.levels.INFO)
+							end
+						end)
+					end)
+				end,
+			})
+		end)
+	end)
 end
 
 return M

--- a/lua/fude/pr.lua
+++ b/lua/fude/pr.lua
@@ -75,10 +75,16 @@ end
 --- Parse title and body from PR buffer contents.
 --- @param title_lines string[] lines from title buffer
 --- @param body_lines string[] lines from body buffer
+--- @param opts table|nil options: { trim_body: boolean (default true) }
 --- @return table { title: string, body: string }
-function M.parse_pr_buffer(title_lines, body_lines)
+function M.parse_pr_buffer(title_lines, body_lines, opts)
+	opts = opts or {}
+	local trim_body = opts.trim_body == nil or opts.trim_body
 	local title = vim.trim(table.concat(title_lines, " "))
-	local body = vim.trim(table.concat(body_lines, "\n"))
+	local body = table.concat(body_lines, "\n")
+	if trim_body then
+		body = vim.trim(body)
+	end
 	return { title = title, body = body }
 end
 
@@ -121,7 +127,7 @@ end
 --- Open the PR float with explicit title and body content.
 --- @param title_lines string[]|nil initial title lines (default: {""})
 --- @param body_lines string[]|nil initial body lines (default: {""})
---- @param opts table|nil options: { mode: "create"|"edit", footer: string, on_submit: fun(title, body) }
+--- @param opts table|nil { mode: "create"|"edit", footer: string, from_draft: boolean, on_submit: fun(...) }
 function M.open_pr_float(title_lines, body_lines, opts)
 	title_lines = title_lines or { "" }
 	body_lines = body_lines or { "" }
@@ -214,20 +220,27 @@ function M.open_pr_float(title_lines, body_lines, opts)
 	local function submit()
 		local t_lines = vim.api.nvim_buf_get_lines(title_buf, 0, -1, false)
 		local b_lines = vim.api.nvim_buf_get_lines(body_buf, 0, -1, false)
-		local parsed = M.parse_pr_buffer(t_lines, b_lines)
+		local parsed = M.parse_pr_buffer(t_lines, b_lines, { trim_body = not is_edit })
 
 		if parsed.title == "" then
 			vim.notify("fude.nvim: PR title is required", vim.log.levels.WARN)
 			return
 		end
 
-		close_all()
-
 		-- Use custom submit handler if provided
 		if opts.on_submit then
-			opts.on_submit(parsed.title, parsed.body)
+			if is_edit then
+				-- Edit mode: let the handler close the float on success.
+				-- On failure the float stays open so the user can retry.
+				opts.on_submit(parsed.title, parsed.body, close_all)
+			else
+				close_all()
+				opts.on_submit(parsed.title, parsed.body)
+			end
 			return
 		end
+
+		close_all()
 
 		-- Default: create draft PR
 		-- Save draft before attempting to create PR
@@ -476,37 +489,56 @@ end
 
 --- Edit the current PR's title and body.
 --- Uses state.pr_number when review mode is active, otherwise detects via gh pr view.
+--- Resolves PR number upfront to avoid detached HEAD issues with both get/edit.
 function M.edit()
 	local pr_number = config.state.active and config.state.pr_number or nil
 
 	vim.notify("fude.nvim: Loading PR...", vim.log.levels.INFO)
 
-	gh.get_pr_title_body(pr_number, function(err, data)
-		vim.schedule(function()
+	local function do_edit(num)
+		gh.get_pr_title_body(num, function(err, data)
+			vim.schedule(function()
+				if err then
+					vim.notify("fude.nvim: " .. err, vim.log.levels.ERROR)
+					return
+				end
+
+				local body_lines = vim.split(data.body or "", "\n", { plain = true })
+				M.open_pr_float({ data.title }, body_lines, {
+					mode = "edit",
+					footer = " <CR> update | q cancel ",
+					on_submit = function(title, body, close_float)
+						vim.notify("fude.nvim: Updating PR...", vim.log.levels.INFO)
+						gh.edit_pr(num, title, body, function(edit_err)
+							vim.schedule(function()
+								if edit_err then
+									vim.notify("fude.nvim: " .. edit_err, vim.log.levels.ERROR)
+								else
+									close_float()
+									vim.notify("fude.nvim: PR updated", vim.log.levels.INFO)
+								end
+							end)
+						end)
+					end,
+				})
+			end)
+		end)
+	end
+
+	if pr_number then
+		do_edit(pr_number)
+	else
+		-- Resolve PR number first (handles detached HEAD via get_pr_info)
+		gh.get_pr_info(function(err, info)
 			if err then
-				vim.notify("fude.nvim: " .. err, vim.log.levels.ERROR)
+				vim.schedule(function()
+					vim.notify("fude.nvim: " .. err, vim.log.levels.ERROR)
+				end)
 				return
 			end
-
-			local body_lines = vim.split(data.body or "", "\n", { plain = true })
-			M.open_pr_float({ data.title }, body_lines, {
-				mode = "edit",
-				footer = " <CR> update | q cancel ",
-				on_submit = function(title, body)
-					vim.notify("fude.nvim: Updating PR...", vim.log.levels.INFO)
-					gh.edit_pr(pr_number, title, body, function(edit_err)
-						vim.schedule(function()
-							if edit_err then
-								vim.notify("fude.nvim: " .. edit_err, vim.log.levels.ERROR)
-							else
-								vim.notify("fude.nvim: PR updated", vim.log.levels.INFO)
-							end
-						end)
-					end)
-				end,
-			})
+			do_edit(info.number)
 		end)
-	end)
+	end
 end
 
 return M

--- a/plugin/fude.lua
+++ b/plugin/fude.lua
@@ -134,6 +134,10 @@ vim.api.nvim_create_user_command("FudeCreatePR", function()
 	require("fude.pr").create()
 end, { desc = "Create draft PR from template" })
 
+vim.api.nvim_create_user_command("FudeEditPR", function()
+	require("fude.pr").edit()
+end, { desc = "Edit PR title and body" })
+
 vim.api.nvim_create_user_command("FudeReviewReload", function()
 	require("fude").reload()
 end, { desc = "Reload review data from GitHub" })

--- a/tests/fude/pr_spec.lua
+++ b/tests/fude/pr_spec.lua
@@ -252,3 +252,125 @@ describe("draft management", function()
 		assert.are.same({ "new body" }, d.body_lines)
 	end)
 end)
+
+describe("edit", function()
+	local gh = require("fude.gh")
+	local config = require("fude.config")
+	local captured_pr_number
+	local captured_title_lines
+	local captured_body_lines
+	local captured_opts
+
+	before_each(function()
+		captured_pr_number = nil
+		captured_title_lines = nil
+		captured_body_lines = nil
+		captured_opts = nil
+		config.reset_state()
+
+		-- Mock open_pr_float to capture arguments
+		helpers.mock(pr, "open_pr_float", function(title_lines, body_lines, opts)
+			captured_title_lines = title_lines
+			captured_body_lines = body_lines
+			captured_opts = opts
+		end)
+	end)
+
+	after_each(function()
+		helpers.cleanup()
+	end)
+
+	it("uses state.pr_number when review mode is active", function()
+		config.state.active = true
+		config.state.pr_number = 42
+
+		helpers.mock(gh, "get_pr_title_body", function(pr_num, callback)
+			captured_pr_number = pr_num
+			vim.schedule(function()
+				callback(nil, { title = "PR Title", body = "PR Body" })
+			end)
+		end)
+
+		pr.edit()
+		helpers.wait_for(function()
+			return captured_pr_number ~= nil
+		end)
+
+		assert.are.equal(42, captured_pr_number)
+	end)
+
+	it("uses nil pr_number when review mode is inactive", function()
+		config.state.active = false
+		config.state.pr_number = nil
+
+		helpers.mock(gh, "get_pr_title_body", function(pr_num, callback)
+			captured_pr_number = pr_num
+			vim.schedule(function()
+				callback(nil, { title = "PR Title", body = "PR Body" })
+			end)
+		end)
+
+		pr.edit()
+		helpers.wait_for(function()
+			return captured_title_lines ~= nil
+		end)
+
+		assert.is_nil(captured_pr_number)
+	end)
+
+	it("opens float with edit mode and correct content", function()
+		config.state.active = false
+
+		helpers.mock(gh, "get_pr_title_body", function(_, callback)
+			vim.schedule(function()
+				callback(nil, { title = "Existing Title", body = "Line 1\nLine 2" })
+			end)
+		end)
+
+		pr.edit()
+		helpers.wait_for(function()
+			return captured_opts ~= nil
+		end)
+
+		assert.are.same({ "Existing Title" }, captured_title_lines)
+		assert.are.same({ "Line 1", "Line 2" }, captured_body_lines)
+		assert.are.equal("edit", captured_opts.mode)
+		assert.are.equal(" <CR> update | q cancel ", captured_opts.footer)
+		assert.is_not_nil(captured_opts.on_submit)
+	end)
+
+	it("on_submit calls gh.edit_pr with correct arguments", function()
+		config.state.active = true
+		config.state.pr_number = 123
+
+		local edit_called_with = nil
+
+		helpers.mock(gh, "get_pr_title_body", function(_, callback)
+			vim.schedule(function()
+				callback(nil, { title = "Original", body = "Body" })
+			end)
+		end)
+
+		helpers.mock(gh, "edit_pr", function(pr_num, title, body, callback)
+			edit_called_with = { pr_number = pr_num, title = title, body = body }
+			vim.schedule(function()
+				callback(nil)
+			end)
+		end)
+
+		pr.edit()
+		helpers.wait_for(function()
+			return captured_opts ~= nil and captured_opts.on_submit ~= nil
+		end)
+
+		-- Simulate submit
+		captured_opts.on_submit("New Title", "New Body")
+		helpers.wait_for(function()
+			return edit_called_with ~= nil
+		end)
+
+		assert.are.equal(123, edit_called_with.pr_number)
+		assert.are.equal("New Title", edit_called_with.title)
+		assert.are.equal("New Body", edit_called_with.body)
+	end)
+end)

--- a/tests/fude/pr_spec.lua
+++ b/tests/fude/pr_spec.lua
@@ -219,6 +219,21 @@ describe("parse_pr_buffer", function()
 		local result = pr.parse_pr_buffer({ "title" }, { "line1", "line2", "line3" })
 		assert.are.equal("line1\nline2\nline3", result.body)
 	end)
+
+	it("does not trim body when trim_body is false", function()
+		local result = pr.parse_pr_buffer({ "title" }, { "", "  body  ", "" }, { trim_body = false })
+		assert.are.equal("\n  body  \n", result.body)
+	end)
+
+	it("trims body by default (trim_body not specified)", function()
+		local result = pr.parse_pr_buffer({ "title" }, { "", "  body  ", "" })
+		assert.are.equal("body", result.body)
+	end)
+
+	it("trims body when trim_body is true", function()
+		local result = pr.parse_pr_buffer({ "title" }, { "", "  body  ", "" }, { trim_body = true })
+		assert.are.equal("body", result.body)
+	end)
 end)
 
 describe("draft management", function()
@@ -299,9 +314,15 @@ describe("edit", function()
 		assert.are.equal(42, captured_pr_number)
 	end)
 
-	it("uses nil pr_number when review mode is inactive", function()
+	it("resolves pr_number via get_pr_info when review mode is inactive", function()
 		config.state.active = false
 		config.state.pr_number = nil
+
+		helpers.mock(gh, "get_pr_info", function(callback)
+			vim.schedule(function()
+				callback(nil, { number = 99, baseRefName = "main", headRefName = "feature", url = "" })
+			end)
+		end)
 
 		helpers.mock(gh, "get_pr_title_body", function(pr_num, callback)
 			captured_pr_number = pr_num
@@ -315,11 +336,17 @@ describe("edit", function()
 			return captured_title_lines ~= nil
 		end)
 
-		assert.is_nil(captured_pr_number)
+		assert.are.equal(99, captured_pr_number)
 	end)
 
 	it("opens float with edit mode and correct content", function()
 		config.state.active = false
+
+		helpers.mock(gh, "get_pr_info", function(callback)
+			vim.schedule(function()
+				callback(nil, { number = 50, baseRefName = "main", headRefName = "feature", url = "" })
+			end)
+		end)
 
 		helpers.mock(gh, "get_pr_title_body", function(_, callback)
 			vim.schedule(function()
@@ -363,8 +390,11 @@ describe("edit", function()
 			return captured_opts ~= nil and captured_opts.on_submit ~= nil
 		end)
 
-		-- Simulate submit
-		captured_opts.on_submit("New Title", "New Body")
+		-- Simulate submit (pass close_float mock as third arg for edit mode)
+		local close_float_called = false
+		captured_opts.on_submit("New Title", "New Body", function()
+			close_float_called = true
+		end)
 		helpers.wait_for(function()
 			return edit_called_with ~= nil
 		end)
@@ -372,5 +402,11 @@ describe("edit", function()
 		assert.are.equal(123, edit_called_with.pr_number)
 		assert.are.equal("New Title", edit_called_with.title)
 		assert.are.equal("New Body", edit_called_with.body)
+
+		-- close_float should be called on success
+		helpers.wait_for(function()
+			return close_float_called
+		end)
+		assert.is_true(close_float_called)
 	end)
 end)


### PR DESCRIPTION
## 概要

既存PRのtitleとbodyを編集する `FudeEditPR` コマンドを追加。

## 変更内容

- `gh.lua`: `get_pr_title_body()` と `edit_pr()` 関数を追加
- `pr.lua`: `open_pr_float()` をリファクタリングし `opts` パラメータを追加、`edit()` 関数を追加
- `plugin/fude.lua`: `FudeEditPR` コマンドを追加
- `tests/fude/pr_spec.lua`: `edit()` のテストを追加
- `doc/fude.txt`: `:FudeEditPR` コマンドのドキュメントを追加
- `CLAUDE.md`: `pr.lua` のモジュール説明を更新

## 使用方法

```
:FudeEditPR
```

- レビューモードアクティブ時 → 現在のセッションのPRを編集
- レビューモード非アクティブ時 → `gh pr view` でPRを自動検出して編集

### キーマップ

- `<Tab>`: タイトル/本文間を移動
- `<CR>`: PRを更新
- `q`: キャンセル

🤖 Generated with [Claude Code](https://claude.ai/code)