### PR TITLE
`FudeEditPR` で ^M 文字が表示されるバグを修正

### DIFF
--- a/lua/fude/comments.lua
+++ b/lua/fude/comments.lua
@@ -1,6 +1,7 @@
 local M = {}
 local config = require("fude.config")
 local diff = require("fude.diff")
+local format = require("fude.ui.format")
 local ui = require("fude.ui")
 local data = require("fude.comments.data")
 local sync = require("fude.comments.sync")
@@ -71,7 +72,7 @@ function M.create_comment(is_visual)
 
 	local pending_key = rel_path .. ":" .. start_line .. ":" .. end_line
 	local existing = state.pending_comments[pending_key]
-	local initial_lines = existing and vim.split(existing.body:gsub("\r\n", "\n"):gsub("\r", "\n"), "\n") or nil
+	local initial_lines = existing and vim.split(format.normalize_newlines(existing.body), "\n") or nil
 
 	ui.open_comment_input(function(comment_body)
 		if comment_body then
@@ -444,8 +445,7 @@ function M.suggest_change(is_visual)
 	vim.list_extend(suggestion_lines, source_lines)
 	table.insert(suggestion_lines, "```")
 
-	local initial_lines = existing and vim.split(existing.body:gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
-		or suggestion_lines
+	local initial_lines = existing and vim.split(format.normalize_newlines(existing.body), "\n") or suggestion_lines
 	local cursor_pos = existing and nil or { 2, 0 }
 
 	ui.open_comment_input(function(comment_body)

--- a/lua/fude/comments.lua
+++ b/lua/fude/comments.lua
@@ -71,7 +71,7 @@ function M.create_comment(is_visual)
 
 	local pending_key = rel_path .. ":" .. start_line .. ":" .. end_line
 	local existing = state.pending_comments[pending_key]
-	local initial_lines = existing and vim.split(existing.body, "\n") or nil
+	local initial_lines = existing and vim.split(existing.body:gsub("\r\n", "\n"):gsub("\r", "\n"), "\n") or nil
 
 	ui.open_comment_input(function(comment_body)
 		if comment_body then
@@ -444,7 +444,8 @@ function M.suggest_change(is_visual)
 	vim.list_extend(suggestion_lines, source_lines)
 	table.insert(suggestion_lines, "```")
 
-	local initial_lines = existing and vim.split(existing.body, "\n") or suggestion_lines
+	local initial_lines = existing and vim.split(existing.body:gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
+		or suggestion_lines
 	local cursor_pos = existing and nil or { 2, 0 }
 
 	ui.open_comment_input(function(comment_body)

--- a/lua/fude/pr.lua
+++ b/lua/fude/pr.lua
@@ -1,6 +1,7 @@
 local M = {}
 local config = require("fude.config")
 local diff = require("fude.diff")
+local format = require("fude.ui.format")
 local gh = require("fude.gh")
 
 --- Template search directory names (for multiple templates).
@@ -503,7 +504,7 @@ function M.edit()
 					return
 				end
 
-				local body_lines = vim.split((data.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n", { plain = true })
+				local body_lines = vim.split(format.normalize_newlines(data.body), "\n", { plain = true })
 				M.open_pr_float({ data.title }, body_lines, {
 					mode = "edit",
 					footer = " <CR> update | q cancel ",

--- a/lua/fude/pr.lua
+++ b/lua/fude/pr.lua
@@ -503,7 +503,7 @@ function M.edit()
 					return
 				end
 
-				local body_lines = vim.split(data.body or "", "\n", { plain = true })
+				local body_lines = vim.split((data.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n", { plain = true })
 				M.open_pr_float({ data.title }, body_lines, {
 					mode = "edit",
 					footer = " <CR> update | q cancel ",

--- a/lua/fude/ui.lua
+++ b/lua/fude/ui.lua
@@ -607,7 +607,7 @@ function M.open_edit_window(thread, comment, opts)
 
 	-- Create lower buffer (editable, pre-filled with comment body)
 	local lower_buf = vim.api.nvim_create_buf(false, true)
-	local initial_lines = vim.split((comment.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
+	local initial_lines = vim.split(format.normalize_newlines(comment.body), "\n")
 	vim.api.nvim_buf_set_lines(lower_buf, 0, -1, false, initial_lines)
 	vim.bo[lower_buf].buftype = "nofile"
 	vim.bo[lower_buf].bufhidden = "wipe"

--- a/lua/fude/ui.lua
+++ b/lua/fude/ui.lua
@@ -607,7 +607,7 @@ function M.open_edit_window(thread, comment, opts)
 
 	-- Create lower buffer (editable, pre-filled with comment body)
 	local lower_buf = vim.api.nvim_create_buf(false, true)
-	local initial_lines = vim.split(comment.body or "", "\n")
+	local initial_lines = vim.split((comment.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
 	vim.api.nvim_buf_set_lines(lower_buf, 0, -1, false, initial_lines)
 	vim.bo[lower_buf].buftype = "nofile"
 	vim.bo[lower_buf].bufhidden = "wipe"

--- a/lua/fude/ui/comment_browser.lua
+++ b/lua/fude/ui/comment_browser.lua
@@ -614,7 +614,7 @@ local function create_browser(entries, issue_comments)
 
 		browser.mode = "edit"
 		browser.edit_target = target_comment
-		local body_lines = vim.split((target_comment.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
+		local body_lines = vim.split(format.normalize_newlines(target_comment.body), "\n")
 		if vim.api.nvim_buf_is_valid(lower_buf) then
 			vim.api.nvim_buf_set_lines(lower_buf, 0, -1, false, body_lines)
 		end

--- a/lua/fude/ui/comment_browser.lua
+++ b/lua/fude/ui/comment_browser.lua
@@ -614,7 +614,7 @@ local function create_browser(entries, issue_comments)
 
 		browser.mode = "edit"
 		browser.edit_target = target_comment
-		local body_lines = vim.split(target_comment.body or "", "\n")
+		local body_lines = vim.split((target_comment.body or ""):gsub("\r\n", "\n"):gsub("\r", "\n"), "\n")
 		if vim.api.nvim_buf_is_valid(lower_buf) then
 			vim.api.nvim_buf_set_lines(lower_buf, 0, -1, false, body_lines)
 		end

--- a/lua/fude/ui/format.lua
+++ b/lua/fude/ui/format.lua
@@ -3,7 +3,7 @@ local M = {}
 --- Normalize newlines by converting CRLF and CR to LF.
 --- @param s string|nil input string
 --- @return string normalized string
-local function normalize_newlines(s)
+function M.normalize_newlines(s)
 	return (s or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
 end
 
@@ -36,7 +36,7 @@ function M.format_comments_for_display(comments, format_date_fn)
 		local header = string.format("@%s  %s", author, created)
 		table.insert(lines, header)
 		table.insert(hl_ranges, { line = #lines - 1, hl = "Title" })
-		local comment_body = normalize_newlines(comment.body)
+		local comment_body = M.normalize_newlines(comment.body)
 		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
 			table.insert(lines, body_line)
 		end
@@ -346,7 +346,7 @@ function M.format_reply_comments_for_display(comments, format_date_fn)
 			{ line = header_line_idx, col_start = ts_start, col_end = ts_end, hl = "ReviewCommentTimestamp" }
 		)
 
-		local comment_body = normalize_newlines(comment.body)
+		local comment_body = M.normalize_newlines(comment.body)
 		for _, body_line in ipairs(vim.split(comment_body, "\n")) do
 			table.insert(lines, body_line)
 		end
@@ -386,7 +386,7 @@ function M.build_overview_left_lines(pr_info, issue_comments, format_date_fn)
 	table.insert(lines, "## DESCRIPTION")
 	sections.description = #lines -- 1-indexed
 
-	local body = normalize_newlines(pr_info.body)
+	local body = M.normalize_newlines(pr_info.body)
 	if body == "" then
 		table.insert(lines, "(no description)")
 	else
@@ -411,7 +411,7 @@ function M.build_overview_left_lines(pr_info, issue_comments, format_date_fn)
 			table.insert(lines, header)
 			table.insert(comment_positions, #lines) -- 1-indexed header line
 			table.insert(hl_ranges, { line = #lines - 1, hl = "Special" })
-			local comment_body = normalize_newlines(comment.body)
+			local comment_body = M.normalize_newlines(comment.body)
 			for _, body_line in ipairs(vim.split(comment_body, "\n")) do
 				table.insert(lines, body_line)
 			end
@@ -937,7 +937,7 @@ function M.format_comments_for_inline(comments, format_date_fn, opts)
 		end
 
 		-- Comment body with wrapping and optional markdown highlighting
-		local body = normalize_newlines(comment.body)
+		local body = M.normalize_newlines(comment.body)
 		local body_lines = vim.split(body, "\n")
 		local in_code_block = false
 

--- a/tests/fude/ui_spec.lua
+++ b/tests/fude/ui_spec.lua
@@ -1,4 +1,31 @@
 local ui = require("fude.ui")
+local format = require("fude.ui.format")
+
+describe("normalize_newlines", function()
+	it("converts CRLF to LF", function()
+		assert.are.equal("a\nb", format.normalize_newlines("a\r\nb"))
+	end)
+
+	it("converts standalone CR to LF", function()
+		assert.are.equal("a\nb", format.normalize_newlines("a\rb"))
+	end)
+
+	it("leaves LF-only strings unchanged", function()
+		assert.are.equal("a\nb\nc", format.normalize_newlines("a\nb\nc"))
+	end)
+
+	it("handles nil input", function()
+		assert.are.equal("", format.normalize_newlines(nil))
+	end)
+
+	it("handles empty string", function()
+		assert.are.equal("", format.normalize_newlines(""))
+	end)
+
+	it("handles mixed line endings", function()
+		assert.are.equal("a\nb\nc\nd", format.normalize_newlines("a\r\nb\rc\nd"))
+	end)
+end)
 
 describe("calculate_float_dimensions", function()
 	it("calculates centered dimensions at 50%", function()


### PR DESCRIPTION
## Summary
- GitHub API が返す PR body やコメント body に含まれる `\r\n` (Windows改行) が、編集バッファにセットされる前に正規化されていなかったため、`^M` として表示されていた
- 表示系 (`ui/format.lua`) では既に `normalize_newlines()` で処理されていたが、編集用バッファへのセット箇所5箇所で漏れていたのを修正

## 修正箇所
- `lua/fude/pr.lua` — PR編集バッファ
- `lua/fude/ui.lua` — コメント編集ウィンドウ
- `lua/fude/comments.lua` — コメント作成・suggest_change（既存pending編集時）
- `lua/fude/ui/comment_browser.lua` — コメントブラウザ編集

## Test plan
- [x] `make all` パス（lint, format-check, 44テスト全パス）
- [x] `\r\n` を含む PR body を持つ PR で `FudeEditPR` を実行し `^M` が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)