### PR TITLE
CI テストマトリクスに Neovim v0.11.7 を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         nvim_version:
           - v0.10.4
+          - v0.11.7
           - stable
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- CI のテストマトリクスに Neovim v0.11.7 を追加
- 既存の v0.10.4（最小サポート）と stable（現在 v0.12.0）の間のバージョンカバレッジを補完

## Test plan
- [ ] CI の Tests (Neovim v0.11.7) ジョブが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)