### PR TITLE
コメントブラウザ左ペインのテキスト切り詰めを除去し nowrap を設定

### DIFF
--- a/lua/fude/ui/comment_browser.lua
+++ b/lua/fude/ui/comment_browser.lua
@@ -124,7 +124,7 @@ local function create_browser(entries, issue_comments)
 
 	-- Format left pane
 	local list_result =
-		format.format_comment_browser_list(entries, 0, config.format_date, config.opts.outdated, config.format_path)
+		format.format_comment_browser_list(entries, config.format_date, config.opts.outdated, config.format_path)
 
 	-- Create left buffer (readonly list)
 	local left_buf = vim.api.nvim_create_buf(false, true)
@@ -320,7 +320,7 @@ local function create_browser(entries, issue_comments)
 			issue_comments = new_issue_comments
 
 			local new_list =
-				format.format_comment_browser_list(new_entries, 0, config.format_date, config.opts.outdated, config.format_path)
+				format.format_comment_browser_list(new_entries, config.format_date, config.opts.outdated, config.format_path)
 			if vim.api.nvim_buf_is_valid(left_buf) then
 				vim.bo[left_buf].modifiable = true
 				vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, new_list.lines)

--- a/lua/fude/ui/comment_browser.lua
+++ b/lua/fude/ui/comment_browser.lua
@@ -123,13 +123,8 @@ local function create_browser(entries, issue_comments)
 	local layout = format.calculate_comment_browser_layout(vim.o.columns, vim.o.lines, ov.width or 80, ov.height or 80)
 
 	-- Format left pane
-	local list_result = format.format_comment_browser_list(
-		entries,
-		layout.left.width,
-		config.format_date,
-		config.opts.outdated,
-		config.format_path
-	)
+	local list_result =
+		format.format_comment_browser_list(entries, 0, config.format_date, config.opts.outdated, config.format_path)
 
 	-- Create left buffer (readonly list)
 	local left_buf = vim.api.nvim_create_buf(false, true)
@@ -171,6 +166,7 @@ local function create_browser(entries, issue_comments)
 		footer_pos = "center",
 	})
 	vim.wo[left_win].cursorline = true
+	vim.wo[left_win].wrap = false
 
 	-- Open upper window (thread, not focused)
 	local upper_win = vim.api.nvim_open_win(upper_buf, false, {
@@ -323,13 +319,8 @@ local function create_browser(entries, issue_comments)
 			entries = new_entries
 			issue_comments = new_issue_comments
 
-			local new_list = format.format_comment_browser_list(
-				new_entries,
-				layout.left.width,
-				config.format_date,
-				config.opts.outdated,
-				config.format_path
-			)
+			local new_list =
+				format.format_comment_browser_list(new_entries, 0, config.format_date, config.opts.outdated, config.format_path)
 			if vim.api.nvim_buf_is_valid(left_buf) then
 				vim.bo[left_buf].modifiable = true
 				vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, new_list.lines)

--- a/lua/fude/ui/format.lua
+++ b/lua/fude/ui/format.lua
@@ -568,7 +568,6 @@ end
 --- Format entries for the comment browser left pane.
 --- Each entry occupies exactly 1 line for direct cursor-to-entry mapping.
 --- @param entries table[] from build_comment_browser_entries
---- @param max_width number available character width
 --- @param format_date_fn fun(s: string): string
 --- @param outdated_opts table|nil { show: boolean, label: string, hl_group: string }
 --- @param format_path_fn fun(s: string): string|nil formats repo-relative path for display (nil = identity)

--- a/lua/fude/ui/format.lua
+++ b/lua/fude/ui/format.lua
@@ -573,7 +573,7 @@ end
 --- @param outdated_opts table|nil { show: boolean, label: string, hl_group: string }
 --- @param format_path_fn fun(s: string): string|nil formats repo-relative path for display (nil = identity)
 --- @return table { lines: string[], hl_ranges: table[] }
-function M.format_comment_browser_list(entries, max_width, format_date_fn, outdated_opts, format_path_fn)
+function M.format_comment_browser_list(entries, format_date_fn, outdated_opts, format_path_fn)
 	local lines = {}
 	local hl_ranges = {}
 
@@ -652,9 +652,6 @@ function M.format_comment_browser_list(entries, max_width, format_date_fn, outda
 			end
 		end
 
-		if max_width > 0 and #text > max_width then
-			text = text:sub(1, max_width - 3) .. "..."
-		end
 		table.insert(lines, text)
 	end
 

--- a/tests/fude/ui_spec.lua
+++ b/tests/fude/ui_spec.lua
@@ -1525,6 +1525,23 @@ describe("format_comment_browser_list", function()
 		assert.is_truthy(result.lines[1]:find("%[pending%]"))
 	end)
 
+	it("preserves full text without truncation for long paths", function()
+		local long_path = "very/long/path/that/is/really/long/file.lua"
+		local entries = {
+			{
+				type = "review",
+				last_ts = "2024-01-01",
+				author = "alice",
+				path = long_path,
+				line = 10,
+				is_pending = false,
+			},
+		}
+		local result = ui.format_comment_browser_list(entries, id_fn)
+		assert.is_truthy(result.lines[1]:find(long_path, 1, true))
+		assert.is_falsy(result.lines[1]:find("%.%.%."))
+	end)
+
 	it("includes highlight ranges for PR Comment", function()
 		local entries = {
 			{ type = "issue", last_ts = "2024-01-01", author = nil, is_pending = false },

--- a/tests/fude/ui_spec.lua
+++ b/tests/fude/ui_spec.lua
@@ -1495,7 +1495,7 @@ describe("format_comment_browser_list", function()
 			},
 			{ type = "issue", last_ts = "2024-01-02T00:00:00Z", author = "bob", is_pending = false },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.are.equal(2, #result.lines)
 	end)
 
@@ -1503,7 +1503,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "src/a.lua", line = 10, is_pending = false },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_truthy(result.lines[1]:find("@alice"))
 		assert.is_truthy(result.lines[1]:find("src/a.lua:10"))
 	end)
@@ -1512,7 +1512,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "issue", last_ts = "2024-01-01", author = nil, is_pending = false },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_truthy(result.lines[1]:find("PR Comment"))
 		assert.is_falsy(result.lines[1]:find("@"))
 	end)
@@ -1521,31 +1521,15 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "src/a.lua", line = 5, is_pending = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_truthy(result.lines[1]:find("%[pending%]"))
-	end)
-
-	it("truncates long lines to max_width", function()
-		local entries = {
-			{
-				type = "review",
-				last_ts = "2024-01-01",
-				author = "alice",
-				path = "very/long/path/that/is/really/long/file.lua",
-				line = 10,
-				is_pending = false,
-			},
-		}
-		local result = ui.format_comment_browser_list(entries, 30, id_fn)
-		assert.is_true(#result.lines[1] <= 30)
-		assert.is_truthy(result.lines[1]:find("%.%.%."))
 	end)
 
 	it("includes highlight ranges for PR Comment", function()
 		local entries = {
 			{ type = "issue", last_ts = "2024-01-01", author = nil, is_pending = false },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_true(#result.hl_ranges > 0)
 		assert.are.equal("DiagnosticInfo", result.hl_ranges[1].hl)
 	end)
@@ -1554,7 +1538,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "a", path = "f.lua", line = 1, is_pending = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_true(#result.hl_ranges > 0)
 		assert.are.equal("DiagnosticHint", result.hl_ranges[1].hl)
 	end)
@@ -1563,7 +1547,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "a", path = "f.lua", line = 1, is_outdated = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_true(result.lines[1]:find("%[outdated%]") ~= nil)
 		assert.is_true(#result.hl_ranges > 0)
 		assert.are.equal("Comment", result.hl_ranges[1].hl)
@@ -1581,7 +1565,7 @@ describe("format_comment_browser_list", function()
 				is_outdated = true,
 			},
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		-- Pending takes precedence
 		assert.is_true(result.lines[1]:find("%[pending%]") ~= nil)
 		assert.is_falsy(result.lines[1]:find("%[outdated%]"))
@@ -1591,13 +1575,13 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "f.lua", line = 1 },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn)
 		assert.is_falsy(result.lines[1]:find("%[outdated%]"))
 		assert.is_true(result.lines[1]:find("@alice") ~= nil)
 	end)
 
 	it("returns empty lines for empty entries", function()
-		local result = ui.format_comment_browser_list({}, 120, id_fn)
+		local result = ui.format_comment_browser_list({}, id_fn)
 		assert.are.equal(0, #result.lines)
 	end)
 
@@ -1605,7 +1589,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "f.lua", line = 1, is_outdated = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, { show = false })
+		local result = ui.format_comment_browser_list(entries, id_fn, { show = false })
 		assert.is_falsy(result.lines[1]:find("%[outdated%]"))
 		-- Should show as normal entry with author
 		assert.is_true(result.lines[1]:find("@alice") ~= nil)
@@ -1615,7 +1599,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "f.lua", line = 1, is_outdated = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, { label = "[OLD]" })
+		local result = ui.format_comment_browser_list(entries, id_fn, { label = "[OLD]" })
 		assert.is_true(result.lines[1]:find("%[OLD%]") ~= nil)
 		assert.is_falsy(result.lines[1]:find("%[outdated%]"))
 	end)
@@ -1624,7 +1608,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "f.lua", line = 1, is_outdated = true },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, { hl_group = "Error" })
+		local result = ui.format_comment_browser_list(entries, id_fn, { hl_group = "Error" })
 		assert.are.equal("Error", result.hl_ranges[1].hl)
 	end)
 
@@ -1635,7 +1619,7 @@ describe("format_comment_browser_list", function()
 		local tail_fn = function(p)
 			return p:match("[^/]+$")
 		end
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, nil, tail_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn, nil, tail_fn)
 		assert.is_truthy(result.lines[1]:find("init.lua:42"))
 		assert.is_falsy(result.lines[1]:find("lua/fude/init.lua"))
 	end)
@@ -1654,7 +1638,7 @@ describe("format_comment_browser_list", function()
 		local tail_fn = function(p)
 			return p:match("[^/]+$")
 		end
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, nil, tail_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn, nil, tail_fn)
 		assert.is_truthy(result.lines[1]:find("config.lua:5"))
 		assert.is_falsy(result.lines[1]:find("lua/fude/config.lua"))
 	end)
@@ -1673,7 +1657,7 @@ describe("format_comment_browser_list", function()
 		local tail_fn = function(p)
 			return p:match("[^/]+$")
 		end
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, nil, tail_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn, nil, tail_fn)
 		assert.is_truthy(result.lines[1]:find("ui.lua:10"))
 		assert.is_falsy(result.lines[1]:find("lua/fude/ui.lua"))
 	end)
@@ -1682,7 +1666,7 @@ describe("format_comment_browser_list", function()
 		local entries = {
 			{ type = "review", last_ts = "2024-01-01", author = "alice", path = "lua/fude/init.lua", line = 42 },
 		}
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, nil, nil)
+		local result = ui.format_comment_browser_list(entries, id_fn, nil, nil)
 		assert.is_truthy(result.lines[1]:find("lua/fude/init.lua:42"))
 	end)
 
@@ -1693,7 +1677,7 @@ describe("format_comment_browser_list", function()
 		local nil_fn = function()
 			return nil
 		end
-		local result = ui.format_comment_browser_list(entries, 120, id_fn, nil, nil_fn)
+		local result = ui.format_comment_browser_list(entries, id_fn, nil, nil_fn)
 		assert.is_truthy(result.lines[1]:find("lua/fude/init.lua:42"))
 	end)
 end)


### PR DESCRIPTION
## 概要

`FudeReviewListComments` のコメントブラウザ左ペイン（スレッド一覧）で、テキストがウィンドウ幅で切り詰められ全文が確認できない問題を修正。truncate を無効化し、`wrap = false` を明示的に設定することで、ペインにフォーカスして横スクロールで全文を確認できるようにした。

## 変更内容

- `format_comment_browser_list` に渡す `max_width` を `layout.left.width` から `0` に変更し、テキストの truncate を無効化
- 左ペインウィンドウに `vim.wo[left_win].wrap = false` を明示的に設定（`style = "minimal"` だけでは `cursorline` 設定後に wrap が有効になるケースがあった）

## テスト計画

- [x] 既存テスト全パス (`make all`)
- [ ] 手動確認: `FudeReviewListComments` で左ペインのテキストが wrap されず、フォーカス時に横スクロールで全文確認可能

## 備考

なし

---
Generated with [Claude Code](https://claude.ai/code)