### PR TITLE
PR作成時のPR Title文字数切り詰め処理を削除

### DIFF
--- a/lua/fude/comments/data.lua
+++ b/lua/fude/comments/data.lua
@@ -371,9 +371,6 @@ function M.build_comment_entries(comment_map, repo_root, format_date_fn, pending
 			local last_ts = last.created_at or ""
 			local last_date = format_date_fn(last_ts)
 			local body_preview = (first.body or ""):gsub("\r?\n", " ")
-			if #body_preview > 60 then
-				body_preview = body_preview:sub(1, 57) .. "..."
-			end
 			local raw = format_path_fn(path)
 			local display_path = type(raw) == "string" and raw or path
 			local label = is_pending and "[pending]" or ("@" .. author)

--- a/tests/fude/comments_spec.lua
+++ b/tests/fude/comments_spec.lua
@@ -717,18 +717,6 @@ describe("data.build_comment_entries", function()
 		assert.are.equal(10, entries[2].lnum)
 	end)
 
-	it("truncates body preview over 60 chars", function()
-		local long_body = string.rep("x", 100)
-		local map = {
-			["a.lua"] = {
-				[1] = { { id = 1, body = long_body, user = { login = "a" }, created_at = "2024-01-01T00:00:00Z" } },
-			},
-		}
-		local entries = data.build_comment_entries(map, "/repo", id_fn)
-		assert.is_true(#entries[1].detail < #long_body, "detail should be shorter than full body")
-		assert.is_truthy(entries[1].detail:match("%.%.%.$"), "truncated detail should end with '...'")
-	end)
-
 	it("returns empty for empty map", function()
 		local entries = data.build_comment_entries({}, "/repo", id_fn)
 		assert.are.same({}, entries)


### PR DESCRIPTION
close https://github.com/flexphere/fude.nvim/issues/113
## Summary
- `build_comment_entries` の `body_preview` で行っていた60文字バイト切り詰め処理を削除
- CJK文字（UTF-8で3バイト）がバイト単位で途中切断され表示が壊れる問題があった。
	- が、そもそも切り詰め処理自体がない方が体験が良い気がしたので機能ごと削除した。
- 対応するテストケースも削除

## Test plan
- [x] `make all` (lint, format-check, test) パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)