### PR TITLE
feat: 空白差分の表示/非表示を切り替える FudeReviewToggleWhitespace コマンドの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ All plugin code lives under `lua/fude/`. The plugin entry point is `plugin/fude.
 | `reload_timer` | init | init |
 | `reloading` | init | init |
 | `gitsigns_reset` | init, scope | init |
+| `iwhite` | init | init |
 | `sidepanel` | ui/sidepanel | ui/sidepanel |
 
 **高リスクフィールド**（多数のモジュールから参照）:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ PR code review inside Neovim. Review GitHub pull requests without leaving your e
 | `:FudeCopyPRURL` | Copy PR URL to clipboard |
 | `:FudeReviewReload` | Reload review data from GitHub |
 | `:FudeReviewToggleCommentStyle` | Toggle comment display style (virtualText/inline) |
+| `:FudeReviewToggleWhitespace` | Toggle whitespace diff ignore (iwhite) |
 | `:FudeReviewToggleGitsigns` | Toggle gitsigns between PR base and HEAD |
 | `:FudeCreatePR` | Create draft PR from template |
 

--- a/doc/fude.txt
+++ b/doc/fude.txt
@@ -341,6 +341,13 @@ Using lazy.nvim: >lua
     or viewed/reviewed state is toggled.
     Configurable via `sidepanel` options. Requires an active session.
 
+:FudeReviewToggleWhitespace            *:FudeReviewToggleWhitespace*
+    Toggle whitespace diff ignore (iwhite) on and off.
+    When enabled, whitespace-only changes are hidden from the diff view.
+    Execute again to show whitespace changes.
+    The setting is automatically restored when review mode stops.
+    Requires an active review session.
+
 :FudeReviewToggleGitsigns              *:FudeReviewToggleGitsigns*
     Toggle gitsigns base between PR base and HEAD.
     By default during review mode, gitsigns uses the PR base (or commit

--- a/lua/fude/config.lua
+++ b/lua/fude/config.lua
@@ -125,6 +125,7 @@ M.state = {
 	reload_timer = nil, -- vim.uv.new_timer() handle for auto-reload
 	reloading = false, -- Guard flag to prevent concurrent reloads
 	gitsigns_reset = false, -- true: HEAD表示(一時的に元のワークツリー状態)、false: PRベース表示
+	iwhite = false, -- true: diffopt に iwhite を追加して空白差分を無視
 	sidepanel = nil, -- { win, buf, scope_entries, file_entries, section_map, augroup }
 }
 
@@ -178,6 +179,7 @@ function M.reset_state()
 		reload_timer = nil,
 		reloading = false,
 		gitsigns_reset = false,
+		iwhite = false,
 		sidepanel = nil,
 	}
 end

--- a/lua/fude/init.lua
+++ b/lua/fude/init.lua
@@ -275,9 +275,9 @@ function M.start()
 			on_ready()
 		end)
 
-		-- Apply diffopt settings
+		-- Save original diffopt (always, so toggle_iwhite changes are restored on stop)
+		state.original_diffopt = vim.o.diffopt
 		if config.opts.diffopt then
-			state.original_diffopt = vim.o.diffopt
 			for _, opt in ipairs(config.opts.diffopt) do
 				vim.opt.diffopt:append(opt)
 			end
@@ -716,6 +716,17 @@ function M.toggle_iwhite()
 		vim.notify("fude.nvim: Not active", vim.log.levels.WARN)
 		return
 	end
+
+	-- Sync state.iwhite with actual diffopt before toggling
+	local diffopt = vim.opt.diffopt:get()
+	local has_iwhite = false
+	for _, opt in ipairs(diffopt) do
+		if opt == "iwhite" then
+			has_iwhite = true
+			break
+		end
+	end
+	state.iwhite = has_iwhite
 
 	if state.iwhite then
 		state.iwhite = false

--- a/lua/fude/init.lua
+++ b/lua/fude/init.lua
@@ -708,6 +708,26 @@ function M.restore_gitsigns_base()
 	end
 end
 
+--- Toggle whitespace diff ignore (iwhite).
+--- When enabled, whitespace-only changes are hidden from the diff view.
+function M.toggle_iwhite()
+	local state = config.state
+	if not state.active then
+		vim.notify("fude.nvim: Not active", vim.log.levels.WARN)
+		return
+	end
+
+	if state.iwhite then
+		state.iwhite = false
+		vim.opt.diffopt:remove("iwhite")
+		vim.notify("fude.nvim: Whitespace diff ON", vim.log.levels.INFO)
+	else
+		state.iwhite = true
+		vim.opt.diffopt:append("iwhite")
+		vim.notify("fude.nvim: Whitespace diff ignored", vim.log.levels.INFO)
+	end
+end
+
 --- Toggle gitsigns base between PR base and HEAD.
 --- When toggled to HEAD, gitsigns uses HEAD as the base to show changes in the working tree.
 --- When toggled back, gitsigns uses the PR base as the base to show changes in the working tree.

--- a/plugin/fude.lua
+++ b/plugin/fude.lua
@@ -153,6 +153,10 @@ vim.api.nvim_create_user_command("FudeReviewToggleCommentStyle", function()
 	require("fude.ui").refresh_extmarks()
 end, { desc = "Toggle comment display style (virtualText/inline)" })
 
+vim.api.nvim_create_user_command("FudeReviewToggleWhitespace", function()
+	require("fude").toggle_iwhite()
+end, { desc = "Toggle whitespace diff (iwhite)" })
+
 vim.api.nvim_create_user_command("FudeReviewToggleGitsigns", function()
 	require("fude").toggle_gitsigns()
 end, { desc = "Toggle gitsigns between PR base and HEAD" })

--- a/tests/fude/init_integration_spec.lua
+++ b/tests/fude/init_integration_spec.lua
@@ -994,4 +994,97 @@ describe("init integration", function()
 			assert.equals(true, reset_base_calls[1].global)
 		end)
 	end)
+
+	describe("toggle_iwhite", function()
+		local original_diffopt
+
+		before_each(function()
+			original_diffopt = vim.o.diffopt
+		end)
+
+		after_each(function()
+			vim.o.diffopt = original_diffopt
+		end)
+
+		it("does nothing when not active", function()
+			config.state.active = false
+			local before = vim.o.diffopt
+
+			init.toggle_iwhite()
+
+			assert.equals(before, vim.o.diffopt)
+		end)
+
+		it("toggles iwhite on when not present", function()
+			config.state.active = true
+			vim.opt.diffopt:remove("iwhite")
+
+			init.toggle_iwhite()
+
+			assert.is_true(config.state.iwhite)
+			local opts = vim.opt.diffopt:get()
+			local found = false
+			for _, opt in ipairs(opts) do
+				if opt == "iwhite" then
+					found = true
+					break
+				end
+			end
+			assert.is_true(found, "iwhite should be in diffopt")
+		end)
+
+		it("toggles iwhite off when present", function()
+			config.state.active = true
+			vim.opt.diffopt:append("iwhite")
+
+			init.toggle_iwhite()
+
+			assert.is_false(config.state.iwhite)
+			local opts = vim.opt.diffopt:get()
+			local found = false
+			for _, opt in ipairs(opts) do
+				if opt == "iwhite" then
+					found = true
+					break
+				end
+			end
+			assert.is_false(found, "iwhite should not be in diffopt")
+		end)
+
+		it("syncs state with actual diffopt when state.iwhite is out of sync", function()
+			config.state.active = true
+			-- User already has iwhite in diffopt, but state.iwhite is false (initial default)
+			vim.opt.diffopt:append("iwhite")
+			config.state.iwhite = false
+
+			-- First toggle should detect iwhite is present and remove it
+			init.toggle_iwhite()
+
+			assert.is_false(config.state.iwhite)
+			local opts = vim.opt.diffopt:get()
+			local found = false
+			for _, opt in ipairs(opts) do
+				if opt == "iwhite" then
+					found = true
+					break
+				end
+			end
+			assert.is_false(found, "iwhite should be removed after toggle")
+		end)
+
+		it("stop restores diffopt even when opts.diffopt is nil", function()
+			config.state.active = true
+			config.state.original_diffopt = vim.o.diffopt
+			local saved = vim.o.diffopt
+
+			-- Simulate toggle_iwhite adding iwhite
+			init.toggle_iwhite()
+			assert.is_true(config.state.iwhite)
+
+			-- Simulate stop restoring diffopt
+			vim.o.diffopt = config.state.original_diffopt
+
+			assert.equals(saved, vim.o.diffopt)
+		end)
+	end)
 end)


### PR DESCRIPTION
## Summary
- レビュー中に `:FudeReviewToggleWhitespace` で `diffopt` の `iwhite` を on/off できるようにした
- 空白のみの変更が多いファイルで diff のノイズを減らせる
- レビューモード終了時は `original_diffopt` の復元により自動クリーンアップされる

## Test plan
- [ ] fude を起動し、空白変更のあるファイルで `:FudeReviewToggleWhitespace` を実行 → diff から空白差分が消えることを確認
- [ ] もう一度実行 → 空白差分が戻ることを確認
- [ ] `:FudeReviewStop` → `diffopt` が元に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)