### PR TITLE
複数hunkファイルでpending commentが表示されないバグを修正

### DIFF
--- a/lua/fude/comments/data.lua
+++ b/lua/fude/comments/data.lua
@@ -22,7 +22,7 @@ function M.line_from_diff_hunk(diff_hunk, position)
 	for hunk_line in diff_hunk:gmatch("[^\n]+") do
 		if not hunk_line:match("^@@") then
 			pos = pos + 1
-			if hunk_line:sub(1, 1) ~= "-" then
+			if hunk_line:sub(1, 1) ~= "-" and hunk_line:sub(1, 1) ~= "\\" then
 				-- Context or addition: belongs to new file
 				if pos == position then
 					return new_line
@@ -36,7 +36,13 @@ function M.line_from_diff_hunk(diff_hunk, position)
 	-- but diff_hunk only contains the hunk where the comment is located.
 	-- GitHub truncates diff_hunk at the comment position, so the last
 	-- new-side line is the commented line.
-	return last_new_line
+	-- Only fall back when position exceeds the hunk (multi-hunk offset);
+	-- if position is within the hunk but didn't match (e.g. deletion line),
+	-- return nil to avoid mapping to the wrong line.
+	if position > pos then
+		return last_new_line
+	end
+	return nil
 end
 
 --- Build a nested lookup map from a flat array of comments.

--- a/lua/fude/comments/data.lua
+++ b/lua/fude/comments/data.lua
@@ -6,7 +6,7 @@ local is_null = util.is_null
 --- The review-specific endpoint (GET /reviews/{id}/comments) returns `position`
 --- instead of `line` for pending review comments. This converts position to line.
 --- @param diff_hunk string the diff hunk text from the API
---- @param position number 1-indexed position within the diff hunk
+--- @param position number 1-indexed position within the file diff (may span multiple hunks)
 --- @return number|nil line number in the new file
 function M.line_from_diff_hunk(diff_hunk, position)
 	if is_null(diff_hunk) or is_null(position) then
@@ -17,6 +17,7 @@ function M.line_from_diff_hunk(diff_hunk, position)
 		return nil
 	end
 	local new_line = new_start
+	local last_new_line = nil
 	local pos = 0
 	for hunk_line in diff_hunk:gmatch("[^\n]+") do
 		if not hunk_line:match("^@@") then
@@ -26,11 +27,16 @@ function M.line_from_diff_hunk(diff_hunk, position)
 				if pos == position then
 					return new_line
 				end
+				last_new_line = new_line
 				new_line = new_line + 1
 			end
 		end
 	end
-	return nil
+	-- position is relative to the entire file diff (across all hunks),
+	-- but diff_hunk only contains the hunk where the comment is located.
+	-- GitHub truncates diff_hunk at the comment position, so the last
+	-- new-side line is the commented line.
+	return last_new_line
 end
 
 --- Build a nested lookup map from a flat array of comments.

--- a/tests/fude/comments_spec.lua
+++ b/tests/fude/comments_spec.lua
@@ -554,9 +554,22 @@ describe("data.line_from_diff_hunk", function()
 		assert.is_nil(data.line_from_diff_hunk("@@ -0,0 +1 @@\n+x", vim.NIL))
 	end)
 
-	it("returns nil when position exceeds hunk lines", function()
+	it("falls back to last new-side line when position exceeds hunk lines", function()
+		-- position is relative to the entire file diff (across all hunks),
+		-- but diff_hunk only contains the relevant hunk. GitHub truncates
+		-- diff_hunk at the comment position, so the last new-side line is correct.
 		local hunk = "@@ -0,0 +1,1 @@\n+only"
-		assert.is_nil(data.line_from_diff_hunk(hunk, 99))
+		assert.are.equal(1, data.line_from_diff_hunk(hunk, 99))
+	end)
+
+	it("falls back correctly for multi-hunk file diff", function()
+		-- Simulates a comment in the 3rd hunk of a file with position=49.
+		-- The diff_hunk only contains the 3rd hunk (truncated at comment position).
+		local hunk = "@@ -59,17 +60,39 @@\n context\n-deleted\n+added\n context2\n+last_line"
+		-- position 49 exceeds the 5 content lines in this hunk.
+		-- Fallback should return the line of the last new-side line.
+		-- new_start=60, non-deletion lines: context(60), added(61), context2(62), last_line(63)
+		assert.are.equal(63, data.line_from_diff_hunk(hunk, 49))
 	end)
 
 	it("returns nil for invalid hunk header", function()

--- a/tests/fude/comments_spec.lua
+++ b/tests/fude/comments_spec.lua
@@ -572,6 +572,18 @@ describe("data.line_from_diff_hunk", function()
 		assert.are.equal(63, data.line_from_diff_hunk(hunk, 49))
 	end)
 
+	it("returns nil when position points to a deletion line within hunk", function()
+		-- position 2 is the deletion line "-deleted"; no RIGHT-side line exists for it.
+		local hunk = "@@ -10,3 +20,3 @@\n context\n-deleted\n+added\n context2"
+		assert.is_nil(data.line_from_diff_hunk(hunk, 2))
+	end)
+
+	it("skips backslash no-newline marker in line count", function()
+		local hunk = "@@ -1,1 +1,1 @@\n-old\n+new\n\\ No newline at end of file"
+		-- position 2 = "+new", new_start=1 → line 1
+		assert.are.equal(1, data.line_from_diff_hunk(hunk, 2))
+	end)
+
 	it("returns nil for invalid hunk header", function()
 		assert.is_nil(data.line_from_diff_hunk("no header here", 1))
 	end)


### PR DESCRIPTION
## Summary
- GitHub API の `position` はファイル全体のdiff内での位置（複数hunkにまたがって累積）だが、`diff_hunk` はコメントが属するhunkのみを含む
- 複数hunkを持つファイルの2番目以降のhunkにあるpending commentで、`line_from_diff_hunk()` が `position` を見つけられず `nil` を返していた
- フォールバックとして `diff_hunk` の最後のnew-side行の行番号を返すようにした（GitHub APIがdiff_hunkをコメント位置で切り詰めるため正しい）

## Test plan
- [x] `make all` pass（lint, format-check, test 44/44）
- [ ] go-api-server-playground PR#99 で fude を起動し、pending comment（`r3069623450`）が表示されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)