### PR TITLE
verify: REST in_reply_to + pending review の挙動検証（merge 予定なし）

### DIFF
--- a/lua/fude/util.lua
+++ b/lua/fude/util.lua
@@ -3,6 +3,7 @@ local M = {}
 --- Check if a value is null (nil or vim.NIL).
 --- JSON null may decode as nil (Neovim 0.11) or vim.NIL (Neovim 0.12).
 --- This helper normalizes both cases for consistent null checking.
+--- Returns true if v is nil or vim.NIL, otherwise false.
 --- @param v any
 --- @return boolean
 function M.is_null(v)


### PR DESCRIPTION
## 目的

PR #127 で実装した GraphQL ベースの reply 経路が必要かどうかを再検証する。

検証対象: \`POST /pulls/{pr}/comments\` + \`in_reply_to\` パラメータ が pending review 存在下で 422 を返すか、それとも動作するか。

## 期待される結果（仮説）

REST API 内部では reply 系も「新規 review を作成する」経路を通るため 422（user_id can only have one pending review per pull request）になると予想。

検証で 422 確定 → PR #127 を採用。
万が一動作 → PR #127 を簡略化する余地あり。

## 注意

このブランチは検証専用で merge する予定はない。検証後は close & delete する。

---
Generated with [Claude Code](https://claude.ai/code)