### PR TITLE
feat: luacov によるテストカバレッジ計測を追加 (local + CI)

### DIFF
--- a/.claude/HARNESS.md
+++ b/.claude/HARNESS.md
@@ -47,7 +47,7 @@ Martin Fowler "Harness Engineering for Coding Agents"
 | 計算的 | `make check-purity` (`scripts/check_purity.lua`) | 開発中・pre-commit・CI | `*/data.lua` `*/format.lua` の純粋性 (vim API・`config.state` 不参照) の検証 |
 | 計算的 | `make check-docs` (`scripts/check_docs.lua`) | 開発中・pre-commit・CI | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向整合性 |
 | 計算的 | `make coverage` (luacov) | 開発中（手動）・CI | `lua/fude/` のテストカバレッジ計測。`make all` には未組み込み（報告のみ・閾値強制なし）。CI artifact `coverage-report` に保管 |
-| 計算的 | `.githooks/pre-commit` | commit | 上記 5 つの検査系を順次実行する **ローカルゲート**（coverage は除外） |
+| 計算的 | `.githooks/pre-commit` | commit | 上記のうち coverage を除く 6 つを順次実行する **ローカルゲート** |
 | 計算的 | `.github/workflows/ci.yml` | PR / push to main | 上記 7 つを CI 上で実行（テストは Neovim 0.10.4 / 0.11.7 / stable の matrix、その他は stable 単一） |
 | 推論的 | `/self-review` ラウンド 1〜2 | PR 前 | `/pj-checklist` を diff に適用して検出・自律修正 |
 | 推論的 | `/self-review` ラウンド 3 | PR 前 | Claude Code 標準の `/review` で汎用観点の検出 |

--- a/.claude/HARNESS.md
+++ b/.claude/HARNESS.md
@@ -46,8 +46,9 @@ Martin Fowler "Harness Engineering for Coding Agents"
 | 計算的 | `make check-state-deps` (`scripts/check_state_deps.lua`) | 開発中・pre-commit・CI | CLAUDE.md State Dependencies テーブル (W/R) と `lua/fude/` 実コードの整合性検証 |
 | 計算的 | `make check-purity` (`scripts/check_purity.lua`) | 開発中・pre-commit・CI | `*/data.lua` `*/format.lua` の純粋性 (vim API・`config.state` 不参照) の検証 |
 | 計算的 | `make check-docs` (`scripts/check_docs.lua`) | 開発中・pre-commit・CI | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向整合性 |
-| 計算的 | `.githooks/pre-commit` | commit | 上記 6 つを順次実行する **ローカルゲート** |
-| 計算的 | `.github/workflows/ci.yml` | PR / push to main | 上記 6 つを CI 上で実行（テストは Neovim 0.10.4 / 0.11.7 / stable の matrix、その他は stable 単一） |
+| 計算的 | `make coverage` (luacov) | 開発中（手動）・CI | `lua/fude/` のテストカバレッジ計測。`make all` には未組み込み（報告のみ・閾値強制なし）。CI artifact `coverage-report` に保管 |
+| 計算的 | `.githooks/pre-commit` | commit | 上記 5 つの検査系を順次実行する **ローカルゲート**（coverage は除外） |
+| 計算的 | `.github/workflows/ci.yml` | PR / push to main | 上記 7 つを CI 上で実行（テストは Neovim 0.10.4 / 0.11.7 / stable の matrix、その他は stable 単一） |
 | 推論的 | `/self-review` ラウンド 1〜2 | PR 前 | `/pj-checklist` を diff に適用して検出・自律修正 |
 | 推論的 | `/self-review` ラウンド 3 | PR 前 | Claude Code 標準の `/review` で汎用観点の検出 |
 | 推論的 | Copilot 自動レビュー | PR | GitHub 上での AI レビュー（fork PR は手動 trigger 要） |
@@ -100,7 +101,8 @@ Fowler の枠組みで埋められる余地を、優先度別の **PR Roadmap** 
 |--------|--------|------|----------|
 | `check_state_deps` | #134-#135 | CLAUDE.md State Dependencies テーブル (W/R) と `lua/fude/` 実コードの整合性 | multi-LHS 代入 `state.a, state.b = ...` は最後の LHS のみ W 検出、動的フィールド `state[key]` は検出不可、greedy file-wide alias スコープのため shadowing で誤検出の可能性（現コードベースに該当ケースなし） |
 | `check_purity` | #136 | `*/data.lua` `*/format.lua` の純粋性（vim API・`config.state` 不参照） | 動的アクセス `vim["api"]`、`require` 経由の間接的副作用、`getmetatable` トリックは検出不可 |
-| `check_docs` | (本 PR) | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向集合差分 | コマンドのみ対象（keymap・config option の双方向検証は別 PR）、helptag に動的記法は無いため検出漏れリスクは小 |
+| `check_docs` | #137 | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向集合差分 | コマンドのみ対象（keymap・config option の双方向検証は別 PR）、helptag に動的記法は無いため検出漏れリスクは小 |
+| `luacov` (`make coverage`) | (本 PR) | `lua/fude/` のテストカバレッジ計測（line-hit 率）。報告のみ、閾値強制なし。CI artifact から取得 | 初期は 45-50% 程度の見込み。閾値強制は段階 3（将来 PR）で検討。`/harness-audit` の sensor 発火率指標とは別の独立メトリクス |
 
 ### 4.2 次に着手する PR 候補
 
@@ -108,8 +110,8 @@ Fowler の枠組みで埋められる余地を、優先度別の **PR Roadmap** 
 
 | 順 | PR 案 | quadrant 強化 | 規模 | 着手判断 |
 |----|------|--------------|------|---------|
-| 1 | **Test coverage 計測 (luacov)** — 報告のみ、閾値強制は当面なし。データが溜まったら最低カバレッジ閾値を導入 | Comp Sensor | 中 | 既存 plenary との統合に既知の罠あれば調整 |
-| 2 | **`/harness-audit` reporting 拡張** — 過去 N PR の sensor 別検出件数を集計、4-quadrant coverage matrix を自動生成 | Inf Sensor (メタ) | 小 (skill のみ) | Fowler の「sensor 発火率」問いに答える基盤 |
+| 1 | **`/harness-audit` reporting 拡張** — 過去 N PR の sensor 別検出件数を集計、4-quadrant coverage matrix を自動生成 | Inf Sensor (メタ) | 小 (skill のみ) | Fowler の「sensor 発火率」問いに答える基盤 |
+| 2 | **luacov 閾値強制 (段階 3)** — 数週間の数値傾向を見てから最低カバレッジゲートを設定 | Comp Sensor | 小 | 蓄積データが揃ってから |
 | 3 | **pre-commit 文脈ヒント** — 変更モジュールから連動して見るべき `/pj-checklist` 項目を提示。`/harness-audit` の発火率データを取った後に着手判断 | Inf Guide / Process | 中 | 過剰ノイズ化リスクあり、効果未確認 |
 | 4 | **check_docs の keymap / config option 拡張** — 現在のコマンド検証を `*:keymap*` / `*g:fude_*` にも拡張 | Comp Sensor | 中 | check_docs と同じパターン、3 つ目スクリプト共通基盤がすでに揃っている |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,38 @@ jobs:
         run: |
           nvim --version
           make check-docs
+
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        run: |
+          curl -sL "https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.appimage" -o nvim.appimage
+          chmod +x nvim.appimage
+          sudo mkdir -p /opt/nvim
+          ./nvim.appimage --appimage-extract > /dev/null
+          sudo ln -sf "$(pwd)/squashfs-root/AppRun" /usr/bin/nvim
+
+      - name: Install luarocks and luacov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y luarocks
+          sudo luarocks install luacov
+
+      - name: Run coverage
+        run: |
+          nvim --version
+          make coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            luacov.report.out
+            luacov.stats.out
+          if-no-files-found: error
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 doc/tags
 .luacheckcache
 .testenv/
+luacov.stats.out
+luacov.report.out

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,23 @@
+-- luacov configuration
+--
+-- Run via:  make coverage  (sets LUACOV=1 and eval `luarocks path`)
+-- Generates: luacov.stats.out (raw), luacov.report.out (formatted)
+
+return {
+	-- Track only plugin source, not tests/scripts/plugin entry point.
+	-- `plugin/fude.lua` is excluded because it only registers user commands
+	-- and is never re-loaded by tests (its coverage would always show as
+	-- "missed", which is noise).
+	include = { "lua/fude" },
+	exclude = {
+		"tests",
+		"scripts",
+		"plugin",
+	},
+
+	statsfile = "luacov.stats.out",
+	reportfile = "luacov.report.out",
+
+	-- Default tick-based stats writer; flushed automatically on exit.
+	tick = false,
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,11 +50,14 @@ make all               # lint + format-check + test + check-state-deps + check-p
 make check-state-deps  # CLAUDE.md の State Dependencies 表と実コードの整合性検証
 make check-purity      # `*/data.lua` `*/format.lua` の純粋性 (vim API / state 不参照) 検証
 make check-docs        # plugin/fude.lua のコマンド登録と doc/fude.txt のタグの双方向整合性検証
+make coverage          # luacov でテストカバレッジ計測 (要 `luarocks install --local luacov`)
 ```
 
 push 前に `make all` が通ることを必ず確認してください。`make setup` で `.githooks/pre-commit` が有効化され、コミット時に自動実行されます。
 
 `make check-*` 系は CLAUDE.md / 純粋性宣言 / `doc/fude.txt` の各「文書化された建前」が実コードと乖離していないかを機械検証します。`make all` / pre-commit / CI で自動実行されるため、手動で個別に走らせる必要はほとんどありませんが、ピンポイントで確認したい場合に利用してください。
+
+`make coverage` は `make all` には含まれません（報告のみ・閾値強制なし）。CI では別 job として実行され、レポートは GitHub Actions の artifact `coverage-report` から取得できます。ローカルで実行する場合は `luarocks install --local luacov` を先に実行してください。
 
 ## テスト
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format format-check test check-state-deps check-purity check-docs all setup
+.PHONY: lint format format-check test check-state-deps check-purity check-docs coverage all setup
 
 lint:
 	luacheck lua/ plugin/ tests/ scripts/
@@ -20,6 +20,19 @@ check-purity:
 
 check-docs:
 	nvim --headless -l scripts/check_docs.lua
+
+# Test coverage via luacov. Requires `luarocks install --local luacov`.
+# `eval $(luarocks path)` exports LUA_PATH so nvim can require("luacov.runner").
+# Stats and report files are gitignored. Not part of `make all` (report-only).
+coverage:
+	@rm -f luacov.stats.out luacov.report.out
+	@eval "$$(luarocks path)" && LUACOV=1 bash run_tests.sh
+	@eval "$$(luarocks path)" && luacov
+	@echo ""
+	@echo "==> Coverage summary:"
+	@awk '/^Summary$$/,0' luacov.report.out
+	@echo ""
+	@echo "==> Full report: luacov.report.out"
 
 all: lint format-check test check-state-deps check-purity check-docs
 

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,6 +3,27 @@ vim.cmd([[set runtimepath+=.]])
 -- Allow tests to require dev scripts under scripts/ (e.g. scripts/check_state_deps.lua)
 package.path = package.path .. ";./scripts/?.lua"
 
+-- Optional luacov instrumentation. Enable via `LUACOV=1` (or use `make coverage`).
+-- When enabled, line-hit stats are accumulated for `lua/fude/` and written to
+-- `luacov.stats.out`, which `luacov` (the reporter) turns into a human-readable
+-- `luacov.report.out`. luacov is loaded via `pcall` so missing installations
+-- fall back to a warning instead of breaking the test run.
+if vim.env.LUACOV then
+	local ok, runner = pcall(require, "luacov.runner")
+	if ok then
+		runner.init({ include = { "lua/fude" } })
+		-- Force-save stats on Vim exit: nvim --headless does not always trigger
+		-- luacov's atexit handler, so we hook VimLeavePre explicitly.
+		vim.api.nvim_create_autocmd("VimLeavePre", {
+			callback = function()
+				runner.save_stats()
+			end,
+		})
+	else
+		print("[coverage] luacov not available; install with `luarocks install --local luacov`")
+	end
+end
+
 local plenary_path = os.getenv("PLENARY_PATH") or vim.fn.expand("~/.local/share/nvim/lazy/plenary.nvim")
 if vim.fn.isdirectory(plenary_path) == 1 then
 	vim.opt.runtimepath:prepend(plenary_path)


### PR DESCRIPTION
## 概要

HARNESS.md §4.2 Roadmap #1 「Test coverage 計測 (luacov)」を実装する。
**段階 1 + 2** として local `make coverage` と CI job 両方を同時に有効化。
閾値強制はなし（**報告のみ**）、まずは数値傾向を可視化することに専念。

base は main (`#137` までマージ済みの最新)。今回は独立 PR (非 stacked)。

## 変更内容

### Local sensor
- **`.luacov` 新規**: include = `lua/fude`、exclude = tests/scripts/plugin。
  `plugin/fude.lua` はコマンド登録のみでテストで再ロードされないため
  常に 0% でノイズになるため exclude
- **`tests/minimal_init.lua`**: `LUACOV=1` 環境変数で opt-in。`pcall` で
  luacov 未インストール時にも壊れない設計。VimLeavePre autocmd で stats
  を強制保存（`nvim --headless` では luacov の atexit が発火しないため）
- **`Makefile`**: `coverage` ターゲット追加。`eval $(luarocks path)` で
  luacov のロードを可能にし、stats を削除してから実行、summary 部分を
  抽出して表示
- **`.gitignore`**: `luacov.stats.out` と `luacov.report.out` を除外

### CI integration
- **`.github/workflows/ci.yml`**: 新規 job "Test Coverage" を追加
  - Neovim stable 1 バージョンのみ（既存 check-* job と同じパターン）
  - luarocks + luacov を apt + luarocks install で system 配下に install
  - `make coverage` を実行
  - `luacov.report.out` と `luacov.stats.out` を artifact `coverage-report`
    として 30 日保管

### ドキュメント
- **`CONTRIBUTING.md`**: `make coverage` を check コマンド一覧に追加、
  `luarocks install --local luacov` 手順と、CI artifact の場所を明記
- **`.claude/HARNESS.md`**:
  - §2 Sensors 表に `make coverage` 行追加（timing は手動・CI、make all
    は除外と明記）
  - §4.1 完了済 Sensor 表に luacov 行を追加
  - §4.2 から #1 を削除、新たに「luacov 閾値強制 (段階 3)」を低優先項目
    として追加
  - 同時に pre-commit 行の検査数表記 typo (「上記 5 つ」→「上記のうち
    coverage を除く 6 つ」) を修正

## 検出結果 — 初回カバレッジデータ

| ファイル | カバレッジ | 評価 |
|---------|-----------|------|
| `comments/data.lua` | **100%** | 純粋関数中心、テストでフルカバー |
| `util.lua` | **100%** | 唯一の is_null 関数がテストされている |
| `ui/format.lua` | **97.60%** | 純粋宣言通り、テストが充実 |
| `ui/inline.lua` | **82.50%** | 公開 API がテストでカバー |
| `init.lua` | 72.56% | ライフサイクルの主要パスはカバー |
| `config.lua` | 71.43% | デフォルト経路は OK |
| `comments/sync.lua` | 67.98% | エラーパスにムラあり |
| `gh.lua` | 51.98% | 外部 CLI のため統合困難な箇所 |
| `files.lua` | 37.41% | ピッカー処理の一部のみ |
| `extmarks.lua` | 26.18% | 表示系で要改善 |
| `scope.lua` | **25.23%** | UI 統合が薄い |
| `diff.lua` | 20.22% | git 呼出のため難しい |
| `comments.lua` | 18.18% | 多くがファサード |
| `preview.lua` | 16.48% | 表示系 |
| `ui.lua` | 10.42% | ファサード |
| `ui/sidepanel.lua` | **8.54%** | テスト不足の最有力候補 |
| **合計** | **~47%** | 純粋層は高い、UI 層が低い構造 |

純粋関数として抽出されたモジュールは高カバレッジ、UI/統合層は低い。
今後の Phase 3 として「最低カバレッジ閾値」を導入する場合の目安に。

## テスト計画

- [x] `make coverage` 通過、`luacov.report.out` 生成
- [x] `make all` / `make test` 引き続き動作（LUACOV 未設定で無影響）
- [x] `make all` の 3 sensor (state-deps / purity / docs) 引き続き 0 件
- [ ] CI workflow の新 job が GitHub Actions 上で正常動作するか
  → PR push 後に確認
- [ ] レビュー時に確認してほしい点:
  - 初回カバレッジ数値の妥当性（純粋層 100%、UI 層 10% 前後の構造）
  - `tests/minimal_init.lua` の VimLeavePre フック設計が許容範囲か

## 備考

- **意図的にやらないこと** (HARNESS.md §4.2 #2 に分離):
  - 閾値強制（段階 3）— 数週間運用してデータ傾向を見てから判断
  - Codecov 等の外部 SaaS 連携 — 内部メトリクスから始める
  - PR コメント自動投稿 — 必要なら別 PR
- **stacking 解除**: PR #133-#137 のマージ完了により、本 PR は main から
  独立した派生となる
- **次の Roadmap**: HARNESS.md §4.2 順に
  1. `/harness-audit` reporting 拡張
  2. luacov 閾値強制 (段階 3)
  3. pre-commit 文脈ヒント
  4. check_docs の keymap / config option 拡張

---
Generated with [Claude Code](https://claude.ai/code)