### PR TITLE
feat: check_docs に config option チェックを追加 (Roadmap #4 の半分)

### DIFF
--- a/.claude/HARNESS.md
+++ b/.claude/HARNESS.md
@@ -45,7 +45,7 @@ Martin Fowler "Harness Engineering for Coding Agents"
 | 計算的 | `bash run_tests.sh` (plenary busted) | 開発中・pre-commit・CI | 単体・統合テスト失敗 |
 | 計算的 | `make check-state-deps` (`scripts/check_state_deps.lua`) | 開発中・pre-commit・CI | CLAUDE.md State Dependencies テーブル (W/R) と `lua/fude/` 実コードの整合性検証 |
 | 計算的 | `make check-purity` (`scripts/check_purity.lua`) | 開発中・pre-commit・CI | `*/data.lua` `*/format.lua` の純粋性 (vim API・`config.state` 不参照) の検証 |
-| 計算的 | `make check-docs` (`scripts/check_docs.lua`) | 開発中・pre-commit・CI | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向整合性 |
+| 計算的 | `make check-docs` (`scripts/check_docs.lua`) | 開発中・pre-commit・CI | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向整合性、および `lua/fude/config.lua` `M.defaults` の top-level 設定キーが `doc/fude.txt` に backtick 形式で文書化されているかの forward 検証 |
 | 計算的 | `make coverage` (luacov) | 開発中（手動）・CI | `lua/fude/` のテストカバレッジ計測。`make all` には未組み込み（報告のみ・閾値強制なし）。CI artifact `coverage-report` に保管 |
 | 計算的 | `.githooks/pre-commit` | commit | 上記のうち coverage を除く 6 つを順次実行する **ローカルゲート** |
 | 計算的 | `.github/workflows/ci.yml` | PR / push to main | 上記 7 つを CI 上で実行（テストは Neovim 0.10.4 / 0.11.7 / stable の matrix、その他は stable 単一） |
@@ -101,7 +101,7 @@ Fowler の枠組みで埋められる余地を、優先度別の **PR Roadmap** 
 |--------|--------|------|----------|
 | `check_state_deps` | #134-#135 | CLAUDE.md State Dependencies テーブル (W/R) と `lua/fude/` 実コードの整合性 | multi-LHS 代入 `state.a, state.b = ...` は最後の LHS のみ W 検出、動的フィールド `state[key]` は検出不可、greedy file-wide alias スコープのため shadowing で誤検出の可能性（現コードベースに該当ケースなし） |
 | `check_purity` | #136 | `*/data.lua` `*/format.lua` の純粋性（vim API・`config.state` 不参照） | 動的アクセス `vim["api"]`、`require` 経由の間接的副作用、`getmetatable` トリックは検出不可 |
-| `check_docs` | #137 | `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向集合差分 | コマンドのみ対象（keymap・config option の双方向検証は別 PR）、helptag に動的記法は無いため検出漏れリスクは小 |
+| `check_docs` | #137, (本 PR) | (1) `plugin/fude.lua` のコマンド登録と `doc/fude.txt` の `*:FudeXxx*` タグの双方向集合差分 (PR #137)、(2) `config.lua` の `M.defaults` top-level キーが doc に backtick 形式で文書化されているか forward 検証 (本 PR) | config option は **forward のみ** (doc backtick は関数名等を含むため reverse 不適)。nested key (`signs.comment` 等) と default value の整合性は未対応。keymap 検証は §4.2 #4 で別 PR 化 |
 | `luacov` (`make coverage`) | (本 PR) | `lua/fude/` のテストカバレッジ計測（line-hit 率）。報告のみ、閾値強制なし。CI artifact から取得 | 初期は 45-50% 程度の見込み。閾値強制は段階 3（将来 PR）で検討。`/harness-audit` の sensor 発火率指標とは別の独立メトリクス |
 
 ### 4.2 次に着手する PR 候補
@@ -112,7 +112,7 @@ Fowler の枠組みで埋められる余地を、優先度別の **PR Roadmap** 
 |----|------|--------------|------|---------|
 | 1 | **luacov 閾値強制 (段階 3)** — 数週間の数値傾向を見てから最低カバレッジゲートを設定 | Comp Sensor | 小 | 蓄積データが揃ってから |
 | 2 | **pre-commit 文脈ヒント** — 変更モジュールから連動して見るべき `/pj-checklist` 項目を提示。`/harness-audit` の発火率データを取った後に着手判断 | Inf Guide / Process | 中 | 過剰ノイズ化リスクあり、効果未確認 |
-| 3 | **check_docs の keymap / config option 拡張** — 現在のコマンド検証を `*:keymap*` / `*g:fude_*` にも拡張 | Comp Sensor | 中 | check_docs と同じパターン、3 つ目スクリプト共通基盤がすでに揃っている |
+| 3 | **check_docs の keymap 検証** — config option は本 PR で実装済。残るは plugin-set keymap (`]c`/`[c` 等) の双方向検証。多くの doc 内 keymap は "suggested" (規約)のため検証対象が限定的 | Comp Sensor | 小〜中 | check_docs と同じパターン、用途が限定的なため優先度は低 |
 
 ### 4.3 やらないこと
 

--- a/doc/fude.txt
+++ b/doc/fude.txt
@@ -457,6 +457,11 @@ Default configuration: >lua
       duration = 200, -- ms
       hl_group = "Visual",
     },
+    -- Buffer-local keymaps set during review mode
+    keymaps = {
+      next_comment = "]c",
+      prev_comment = "[c",
+    },
     -- Comment display style: "virtualText" or "inline"
     comment_style = "virtualText",
     -- Inline display options (used when comment_style = "inline")
@@ -552,6 +557,14 @@ Options:
                   when navigating to a comment line (default: 200).
 
 `flash.hl_group`    Highlight group for the flash effect (default: "Visual").
+
+`keymaps.next_comment`
+                  Buffer-local mapping for next-comment navigation, set
+                  during review mode and removed on stop (default: "]c").
+
+`keymaps.prev_comment`
+                  Buffer-local mapping for previous-comment navigation,
+                  set during review mode and removed on stop (default: "[c").
 
 `auto_view_comment` When true, automatically opens the comment viewer
                   float after navigating to a comment line via ]c, [c,

--- a/scripts/check_docs.lua
+++ b/scripts/check_docs.lua
@@ -2,9 +2,12 @@
 --
 -- Computational Documentation Fitness Sensor.
 --
--- Verifies that user commands registered in `plugin/fude.lua` via
--- `nvim_create_user_command("FudeXxx", ...)` have a matching `*:FudeXxx*`
--- helptag entry in `doc/fude.txt`, and vice versa.
+-- Verifies that user-facing surfaces in code are documented in `doc/fude.txt`:
+--   1. Commands registered via `nvim_create_user_command("FudeXxx", ...)` in
+--      `plugin/fude.lua` have a matching `*:FudeXxx*` helptag (bidirectional)
+--   2. Top-level config keys defined in `M.defaults = { ... }` in
+--      `lua/fude/config.lua` appear as `` `<key>` `` backtick references in
+--      `doc/fude.txt` (forward only — see "Known limitations" below)
 --
 -- See .claude/HARNESS.md §2 for the conceptual framing.
 --
@@ -15,6 +18,17 @@
 --   0 = no discrepancies
 --   1 = discrepancies found
 --   2 = setup / IO error
+--
+-- Known limitations (HARNESS.md §4.1 で追跡):
+--   * Config option check is forward-only (code → doc). Reverse direction
+--     (doc backticks not in code) is too fuzzy: doc references many non-config
+--     identifiers (function names, type names, helptags) via backticks.
+--   * Nested config keys (`signs.comment` 等) are not validated individually;
+--     only top-level keys (`signs`) are checked for existence.
+--   * Default value parity (doc-shown values vs code defaults) is out of scope.
+--   * Keymap validation is out of scope: most documented keymaps are
+--     "suggested" (not plugin-set), and the few plugin-set ones (`]c`/`[c`)
+--     are mentioned in prose without structured tags.
 
 -- Bootstrap package.path so direct execution can resolve `require("lib.lua_source")`.
 package.path = "scripts/?.lua;" .. package.path
@@ -40,9 +54,6 @@ M.strip_comments_only = lua_source.strip_comments_only
 function M.extract_registered_commands(plugin_text)
 	local cleaned = lua_source.strip_comments_only(plugin_text)
 	local set = {}
-	-- Note: stripping converts "FudeFoo" inside a string literal to spaces, so
-	-- the matched name comes only from real source code.
-	-- Both double- and single-quoted forms are supported.
 	for name in cleaned:gmatch('nvim_create_user_command%(%s*"([%w_]+)"') do
 		set[name] = true
 	end
@@ -70,24 +81,98 @@ function M.extract_documented_commands(doc_text)
 end
 
 ----------------------------------------------------------------
--- 3. Compare and report
+-- 3. Extract top-level config option keys from lua/fude/config.lua
 ----------------------------------------------------------------
 
---- Compute set differences between registered and documented commands.
---- @param registered table<string, boolean>
---- @param documented table<string, boolean>
+--- Extract top-level keys defined inside `M.defaults = { ... }`. Walks the
+--- balanced `{...}` block tracking nesting depth, capturing `identifier =`
+--- patterns only at depth 1 (immediately inside the outer braces).
+---
+--- Comments and string literals are stripped first so e.g. an example
+--- `M.defaults = {...}` appearing inside a docstring is ignored.
+---
+--- @param config_text string  raw Lua source of lua/fude/config.lua
+--- @return table<string, boolean>  set of top-level config option names
+function M.extract_config_options(config_text)
+	local cleaned = lua_source.strip_comments_strings(config_text)
+	local block = cleaned:match("M%.defaults%s*=%s*(%b{})")
+	if not block then
+		return {}
+	end
+
+	local set = {}
+	local depth = 0
+	local i = 1
+	while i <= #block do
+		local c = block:sub(i, i)
+		if c == "{" then
+			depth = depth + 1
+		elseif c == "}" then
+			depth = depth - 1
+		elseif depth == 1 then
+			-- Try to match `identifier =` (table key with `=` value form).
+			-- This excludes positional values and keys using `[expr]` form.
+			local _, e, id = block:find("^([%w_]+)%s*=", i)
+			if id then
+				set[id] = true
+				i = e
+			end
+		end
+		i = i + 1
+	end
+	return set
+end
+
+----------------------------------------------------------------
+-- 4. Extract documented config option references from doc/fude.txt
+----------------------------------------------------------------
+
+--- Extract backtick-quoted identifiers from doc/fude.txt. Used to verify
+--- config keys are *mentioned somewhere* in the doc (in either the example
+--- code block or the prose Options: section).
+---
+--- Returns a superset of "config options" because backticks also wrap
+--- function names, helptags, etc. — fine for the forward check ("is X
+--- mentioned?") but unsuitable for a reverse check.
+---
+--- Both `` `foo` `` and `` `foo.bar` `` forms are included; only the
+--- top-level identifier is captured (e.g. `signs.comment` is also indexed
+--- under `signs`).
+---
+--- @param doc_text string  raw vim help text
+--- @return table<string, boolean>  set of mentioned identifiers
+function M.extract_documented_options(doc_text)
+	local set = {}
+	-- Standalone backtick-quoted identifier: `id`
+	for id in doc_text:gmatch("`([%w_]+)`") do
+		set[id] = true
+	end
+	-- Dotted forms like `signs.comment` — also index the top-level identifier
+	for id in doc_text:gmatch("`([%w_]+)%.[%w_.]+`") do
+		set[id] = true
+	end
+	return set
+end
+
+----------------------------------------------------------------
+-- 5. Compare and report
+----------------------------------------------------------------
+
+--- Compute set differences between `code_set` and `doc_set`.
+--- @param code_set table<string, boolean>
+--- @param doc_set table<string, boolean>
 --- @return { undocumented: string[], stale: string[] }
-function M.compare(registered, documented)
+function M.compare(code_set, doc_set)
 	local undocumented = {}
 	local stale = {}
-	for cmd in pairs(registered) do
-		if not documented[cmd] then
-			table.insert(undocumented, cmd)
+	for item in pairs(code_set) do
+		if not doc_set[item] then
+			table.insert(undocumented, item)
 		end
 	end
-	for cmd in pairs(documented) do
-		if not registered[cmd] then
-			table.insert(stale, cmd)
+	for item in pairs(doc_set) do
+		if not code_set[item] then
+			table.insert(stale, item)
 		end
 	end
 	table.sort(undocumented)
@@ -95,35 +180,84 @@ function M.compare(registered, documented)
 	return { undocumented = undocumented, stale = stale }
 end
 
---- Format a human-readable report.
---- @param diff { undocumented: string[], stale: string[] }
---- @return string report, number total
-function M.format_report(diff)
-	local lines = {}
-	local total = 0
+-- Section labels keyed by category name.
+local SECTION_LABELS = {
+	commands = {
+		undoc_label = "Undocumented commands",
+		undoc_hint = "registered in plugin/fude.lua but missing from doc/fude.txt",
+		stale_label = "Stale documentation",
+		stale_hint = "documented in doc/fude.txt but not registered in plugin/fude.lua",
+		item_prefix = ":",
+	},
+	options = {
+		undoc_label = "Undocumented config options",
+		undoc_hint = "defined in lua/fude/config.lua M.defaults but missing from doc/fude.txt",
+		stale_label = "Stale config option documentation",
+		stale_hint = "referenced in doc/fude.txt but not in lua/fude/config.lua M.defaults",
+		item_prefix = "",
+	},
+}
 
+-- Stable section ordering for deterministic output.
+local SECTION_ORDER = { "commands", "options" }
+
+-- Internal: format a single category's lines (no global trailer).
+local function format_section(diff, labels)
+	local lines = {}
+	local count = 0
 	if #diff.undocumented > 0 then
 		table.insert(lines, "")
-		table.insert(lines, string.format("## Undocumented commands (%d)", #diff.undocumented))
-		table.insert(lines, "  -- registered in plugin/fude.lua but missing from doc/fude.txt")
-		for _, cmd in ipairs(diff.undocumented) do
-			table.insert(lines, "  - :" .. cmd)
+		table.insert(lines, string.format("## %s (%d)", labels.undoc_label, #diff.undocumented))
+		table.insert(lines, "  -- " .. labels.undoc_hint)
+		for _, item in ipairs(diff.undocumented) do
+			table.insert(lines, "  - " .. labels.item_prefix .. item)
 		end
-		total = total + #diff.undocumented
+		count = count + #diff.undocumented
 	end
-
 	if #diff.stale > 0 then
 		table.insert(lines, "")
-		table.insert(lines, string.format("## Stale documentation (%d)", #diff.stale))
-		table.insert(lines, "  -- documented in doc/fude.txt but not registered in plugin/fude.lua")
-		for _, cmd in ipairs(diff.stale) do
-			table.insert(lines, "  - :" .. cmd)
+		table.insert(lines, string.format("## %s (%d)", labels.stale_label, #diff.stale))
+		table.insert(lines, "  -- " .. labels.stale_hint)
+		for _, item in ipairs(diff.stale) do
+			table.insert(lines, "  - " .. labels.item_prefix .. item)
 		end
-		total = total + #diff.stale
+		count = count + #diff.stale
+	end
+	return lines, count
+end
+
+--- Format a human-readable report.
+---
+--- Accepts either:
+---   * single-category diff (backward-compat): `{ undocumented = [], stale = [] }`
+---     — treated as the `commands` category
+---   * multi-category map: `{ commands = diff, options = diff }`
+---
+--- @param input table
+--- @return string report, number total
+function M.format_report(input)
+	local sections
+	if input.undocumented or input.stale then
+		sections = { commands = input }
+	else
+		sections = input
+	end
+
+	local lines = {}
+	local total = 0
+	for _, name in ipairs(SECTION_ORDER) do
+		local diff = sections[name]
+		if diff then
+			local sec_lines, sec_count = format_section(diff, SECTION_LABELS[name])
+			for _, line in ipairs(sec_lines) do
+				table.insert(lines, line)
+			end
+			total = total + sec_count
+		end
 	end
 
 	if total == 0 then
-		table.insert(lines, "OK: plugin/fude.lua commands match doc/fude.txt (0 discrepancies).")
+		table.insert(lines, "OK: doc/fude.txt matches plugin/fude.lua and lua/fude/config.lua (0 discrepancies).")
 	else
 		table.insert(lines, "")
 		table.insert(lines, string.format("FAIL: %d documentation discrepancies found.", total))
@@ -133,7 +267,7 @@ function M.format_report(diff)
 end
 
 ----------------------------------------------------------------
--- 4. Main entry
+-- 6. Main entry
 ----------------------------------------------------------------
 
 local function read_file(path)
@@ -158,11 +292,29 @@ function M.main()
 		io.stderr:write("Error: cannot open doc/fude.txt: " .. (derr or "") .. "\n")
 		return 2
 	end
+	local config_text, cerr = read_file("lua/fude/config.lua")
+	if not config_text then
+		io.stderr:write("Error: cannot open lua/fude/config.lua: " .. (cerr or "") .. "\n")
+		return 2
+	end
 
-	local registered = M.extract_registered_commands(plugin_text)
-	local documented = M.extract_documented_commands(doc_text)
-	local diff = M.compare(registered, documented)
-	local report, total = M.format_report(diff)
+	local registered_commands = M.extract_registered_commands(plugin_text)
+	local documented_commands = M.extract_documented_commands(doc_text)
+	local config_options = M.extract_config_options(config_text)
+	local documented_options = M.extract_documented_options(doc_text)
+
+	-- Commands: bidirectional (undocumented + stale).
+	local commands_diff = M.compare(registered_commands, documented_commands)
+	-- Options: forward only (code → doc). Discard `stale` because doc backticks
+	-- include many non-config identifiers (function names, helptags) and would
+	-- yield massive noise. The reverse check is documented as out of scope.
+	local options_diff = M.compare(config_options, documented_options)
+	options_diff.stale = {}
+
+	local report, total = M.format_report({
+		commands = commands_diff,
+		options = options_diff,
+	})
 	print(report)
 	return total > 0 and 1 or 0
 end

--- a/tests/fude/scripts/check_docs_spec.lua
+++ b/tests/fude/scripts/check_docs_spec.lua
@@ -144,4 +144,112 @@ describe("check_docs.format_report", function()
 		assert.is_truthy(report:find("Undocumented"))
 		assert.is_falsy(report:find("Stale"))
 	end)
+
+	it("accepts a multi-category map of {commands=..., options=...}", function()
+		local report, total = check.format_report({
+			commands = { undocumented = { "NewCmd" }, stale = {} },
+			options = { undocumented = { "new_opt" }, stale = {} },
+		})
+		assert.are.equal(2, total)
+		assert.is_truthy(report:find("Undocumented commands %(1%)"))
+		assert.is_truthy(report:find("Undocumented config options %(1%)"))
+	end)
+
+	it("emits OK trailer for empty multi-category input", function()
+		local report, total = check.format_report({
+			commands = { undocumented = {}, stale = {} },
+			options = { undocumented = {}, stale = {} },
+		})
+		assert.are.equal(0, total)
+		assert.is_truthy(report:find("OK"))
+	end)
+end)
+
+describe("check_docs.extract_config_options", function()
+	it("captures top-level keys from M.defaults = { ... }", function()
+		local src = [[
+M.defaults = {
+	foo = 1,
+	bar = "hello",
+	baz = true,
+}
+]]
+		local set = check.extract_config_options(src)
+		assert.is_true(set.foo)
+		assert.is_true(set.bar)
+		assert.is_true(set.baz)
+	end)
+
+	it("does NOT capture nested keys", function()
+		local src = [[
+M.defaults = {
+	signs = {
+		comment = "#",
+		pending = "P",
+	},
+	float = {
+		border = "single",
+	},
+}
+]]
+		local set = check.extract_config_options(src)
+		assert.is_true(set.signs)
+		assert.is_true(set.float)
+		assert.is_nil(set.comment) -- nested
+		assert.is_nil(set.pending) -- nested
+		assert.is_nil(set.border) -- nested
+	end)
+
+	it("handles nil/false/function values", function()
+		local src = [[
+M.defaults = {
+	maybe = nil,
+	flag = false,
+	format_path = nil,
+	on_event = function() return 1 end,
+}
+]]
+		local set = check.extract_config_options(src)
+		assert.is_true(set.maybe)
+		assert.is_true(set.flag)
+		assert.is_true(set.format_path)
+		assert.is_true(set.on_event)
+	end)
+
+	it("ignores M.defaults references inside comments and strings", function()
+		local src = [[
+-- M.defaults = { ghost = 1 }
+local example = "M.defaults = { other_ghost = 2 }"
+M.defaults = {
+	real_key = 1,
+}
+]]
+		local set = check.extract_config_options(src)
+		assert.is_true(set.real_key)
+		assert.is_nil(set.ghost)
+		assert.is_nil(set.other_ghost)
+	end)
+
+	it("returns empty set when M.defaults is absent", function()
+		local set = check.extract_config_options("local M = {}\nreturn M\n")
+		assert.are.equal(0, vim.tbl_count(set))
+	end)
+end)
+
+describe("check_docs.extract_documented_options", function()
+	it("captures standalone backtick-quoted identifiers", function()
+		local set = check.extract_documented_options("Use `foo` and `bar` for setup.\n")
+		assert.is_true(set.foo)
+		assert.is_true(set.bar)
+	end)
+
+	it("indexes the top-level identifier of dotted forms", function()
+		local set = check.extract_documented_options("`signs.comment` sets the indicator.\n")
+		assert.is_true(set.signs)
+	end)
+
+	it("returns empty set for doc with no backtick references", function()
+		local set = check.extract_documented_options("Plain prose with no code refs.\n")
+		assert.are.equal(0, vim.tbl_count(set))
+	end)
 end)


### PR DESCRIPTION
## 概要

HARNESS.md §4.2 #4「check_docs の keymap / config option 拡張」のうち
**config option 部分**を実装する。`lua/fude/config.lua` の
`M.defaults = {...}` に定義された top-level 設定キーが `doc/fude.txt` に
backtick 形式 (`` `<key>` ``) で文書化されているかを機械検証する。

keymap 検証は scope 過大かつ「suggested mappings」が多く検証対象が
限定的なため、本 PR では除外し HARNESS.md §4.2 #4 を keymap 専用に
縮小して残す。

## 変更内容

### Sensor 拡張

- **`scripts/check_docs.lua`**:
  - `extract_config_options(config_text)`: `M.defaults = {...}` ブロックを
    ブレース深度トラッキングで walk し、depth 1 の `identifier =` パターン
    のみを top-level キーとして抽出
  - `extract_documented_options(doc_text)`: doc/fude.txt の `` `id` `` と
    `` `id.field` `` 形式の backtick 参照から top-level identifier を抽出
  - `format_report`: 後方互換シグネチャを拡張。既存の単一カテゴリ入力
    `{undocumented, stale}` に加え、複数カテゴリ `{commands, options}` も
    受け付け、両方を含むレポートを生成 (既存 22 テスト無修正でパス)
  - `main`: commands と options 両方の整合性を検証。options は forward
    only (code → doc) でレポート (reverse 検証は doc backtick の多義性
    のため不適、scope 外として skill 上部 docstring に明記)

- **`tests/fude/scripts/check_docs_spec.lua`**: +10 テスト (全 32 件)
  - `extract_config_options`: top-level capture、nested 除外、nil/false/
    function 値、コメント/文字列内除外、M.defaults 不在の 5 件
  - `extract_documented_options`: standalone・dotted・空 doc の 3 件
  - `format_report`: multi-category 入力、空時 OK の 2 件

### ドリフト修正 (sensor 初回検出)

- **`doc/fude.txt`**: `keymaps` 設定オプションを追記
  - Configuration code block に `keymaps = { next_comment = "]c", prev_comment = "[c" }` を追加
  - Options: 節に `keymaps.next_comment` と `keymaps.prev_comment` を追加

### ドキュメント

- **`.claude/HARNESS.md`**:
  - §2 Sensors 表の check-docs 役割記述を拡張
  - §4.1 完了済 Sensor 表の check_docs を (PR #137 + 本 PR の 2 段階) に更新、
    既知の限界も明記
  - §4.2 PR 候補 #4 を「keymap 検証のみ」に縮小、優先度を低に調整

## 初回検出結果

`keymaps` 設定オプションが doc/fude.txt に未文書化であることを検出。
本 PR の 2 コミット目で追記済 (現在 sensor は 0 discrepancies)。

## 副次的な発見（本 PR では対応せず）

`config.lua` の `keymaps` defaults には以下のフィールドが定義されているが、
コード上で実際に使われているのは `next_comment` と `prev_comment` のみ:

| フィールド | コード使用 | 本 PR で文書化 |
|------------|:---------:|:-------------:|
| `next_comment` | ✓ | ✓ |
| `prev_comment` | ✓ | ✓ |
| `create_comment` | ✗ (dead) | ✗ |
| `view_comments` | ✗ (dead) | ✗ |
| `reply_comment` | ✗ (dead) | ✗ |

Dead fields はコード側 cleanup の候補として残し、本 PR では稼働している
フィールドのみ文書化した (透明性のため commit メッセージにも明記)。

## テスト計画

- [x] `make all` 通過 (lint + format + 44 plenary + 32 check_docs + 3 sensors)
- [x] `make check-docs` → 0 discrepancies
- [x] 既存 22 テストが無修正でパス（format_report 後方互換）
- [x] 新規 10 テストが pass
- [ ] CI workflow 上で正常動作するか
  → PR push 後に確認
- [ ] レビュー時に確認してほしい点:
  - dead fields (`create_comment` 等) の扱い (本 PR スキップでよいか)
  - format_report の多態化が許容範囲か

## 備考

- **既知の限界** (HARNESS.md §4.1 記載):
  - Config option check は **forward only** (code → doc)
  - Nested key (`signs.comment` 等) の検証は対象外、top-level のみ
  - Default value parity (doc-shown 値 vs code defaults) は scope 外
  - Keymap 検証は §4.2 #4 で別 PR 化
- **次の Roadmap** (PR #139 マージ後の状態で):
  1. luacov 閾値強制 (段階 3) — データ蓄積後
  2. pre-commit 文脈ヒント — /harness-audit データ後
  3. check_docs の keymap 検証 — 本 PR で縮小済

---
Generated with [Claude Code](https://claude.ai/code)